### PR TITLE
Add HTML code block highlighting

### DIFF
--- a/js/highlight/html.js
+++ b/js/highlight/html.js
@@ -1,0 +1,36 @@
+import { escapeHtml } from '../utils/escapeHtml.js';
+
+export function highlightHtml(source) {
+  const esc = escapeHtml;
+  return source
+    .split(/(<!--[\s\S]*?-->|<\/?.*?>)/g)
+    .map((part) => {
+      if (!part) return "";
+      if (/^<!--/.test(part)) {
+        return `<span class="hl-comment">${esc(part)}</span>`;
+      }
+      if (/^</.test(part)) {
+        const isClosing = /^<\//.test(part);
+        const selfClose = /\/\s*>$/.test(part);
+        const tagNameMatch = part.match(/^<\/?\s*([^\s>]+)/);
+        const tagName = tagNameMatch ? tagNameMatch[1] : "";
+        let result =
+          "&lt;" +
+          (isClosing ? "/" : "") +
+          `<span class="hl-tag">${tagName}</span>`;
+        let attrString = part.slice(tagNameMatch[0].length);
+        attrString = attrString.replace(/\/?\s*>$/, "");
+        const attrRegex = /([a-zA-Z-:]+)(\s*=\s*(".*?"|'.*?'|[^\s"'>]+))?/g;
+        attrString.replace(attrRegex, (m, name, rest, value) => {
+          result += ` <span class="hl-attr">${name}</span>`;
+          if (value) {
+            result += `=<span class="hl-string">${esc(value)}</span>`;
+          }
+        });
+        result += selfClose ? " /&gt;" : "&gt;";
+        return result;
+      }
+      return esc(part);
+    })
+    .join("");
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,10 @@
+import { parseMarkdown } from './parser/markdown.js';
+
+const editor = document.getElementById('editor');
+const preview = document.getElementById('preview');
+
+editor.addEventListener('input', () => {
+  preview.innerHTML = parseMarkdown(editor.value);
+});
+
+preview.innerHTML = parseMarkdown(editor.value);

--- a/js/parser/markdown.js
+++ b/js/parser/markdown.js
@@ -1,0 +1,156 @@
+import { escapeHtml } from '../utils/escapeHtml.js';
+import { highlightHtml } from '../highlight/html.js';
+
+export function parseMarkdown(md) {
+  const lines = md.split(/\n/);
+  const out = [];
+  let inCodeBlock = false;
+  let codeBlockLang = "";
+  let inPre = false;
+  let tableBuffer = [];
+  let inList = false,
+    inOl = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+
+    const fenceMatch = line.match(/^(```|~~~)\s*(\w+)?\s*$/);
+    if (fenceMatch) {
+      if (!inCodeBlock) {
+        inCodeBlock = true;
+        codeBlockLang = (fenceMatch[2] || "").toLowerCase();
+        out.push("<pre><code>");
+      } else {
+        inCodeBlock = false;
+        codeBlockLang = "";
+        out.push("</code></pre>");
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      if (codeBlockLang === "html") {
+        out.push(highlightHtml(line));
+      } else {
+        out.push(escapeHtml(line));
+      }
+      continue;
+    }
+
+    if (/^\s{4,}/.test(line)) {
+      if (!inPre) {
+        out.push("<pre>");
+        inPre = true;
+      }
+      out.push(escapeHtml(line));
+      continue;
+    } else if (inPre) {
+      out.push("</pre>");
+      inPre = false;
+    }
+
+    if (/^\|.*\|$/.test(line)) {
+      tableBuffer.push(line);
+      continue;
+    } else if (tableBuffer.length > 0) {
+      out.push(renderTable(tableBuffer));
+      tableBuffer = [];
+    }
+
+    if (/^\s*$/.test(line)) {
+      out.push("<br>");
+      continue;
+    }
+
+    if (/^#{1,6} /.test(line)) {
+      const level = line.match(/^#+/)[0].length;
+      out.push(`<h${level}>${line.slice(level).trim()}</h${level}>`);
+      continue;
+    }
+
+    if (/^>+ /.test(line)) {
+      line = line.replace(/^>+ /, "").trim();
+      out.push(`<blockquote>${line}</blockquote>`);
+      continue;
+    }
+
+    if (/^\*{3,}|-{3,}|_{3,}/.test(line)) {
+      out.push("<hr>");
+      continue;
+    }
+
+    if (/^\d+\. /.test(line)) {
+      if (!inOl) {
+        out.push("<ol>");
+        inOl = true;
+      }
+      out.push(`<li>${line.replace(/^\d+\. /, "")}</li>`);
+      continue;
+    } else if (inOl) {
+      out.push("</ol>");
+      inOl = false;
+    }
+
+    if (/^[-+*] /.test(line)) {
+      if (!inList) {
+        out.push("<ul>");
+        inList = true;
+      }
+      out.push(`<li>${line.replace(/^[-+*] /, "")}</li>`);
+      continue;
+    } else if (inList) {
+      out.push("</ul>");
+      inList = false;
+    }
+
+    line = line
+      .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
+      .replace(/___(.+?)___/g, "<strong><em>$1</em></strong>")
+      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+      .replace(/__(.+?)__/g, "<strong>$1</strong>")
+      .replace(/\*(.+?)\*/g, "<em>$1</em>")
+      .replace(/_(.+?)_/g, "<em>$1</em>")
+      .replace(/`(.+?)`/g, "<code>$1</code>")
+      .replace(/!\[(.*?)\]\((.*?)\)/g, '<img alt="$1" src="$2">')
+      .replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2" target="_blank">$1</a>');
+
+    out.push(`<p>${line}</p>`);
+  }
+
+  if (inPre) out.push("</pre>");
+  if (inList) out.push("</ul>");
+  if (inOl) out.push("</ol>");
+  if (tableBuffer.length > 0) out.push(renderTable(tableBuffer));
+
+  return out.join("\n");
+}
+
+function renderTable(lines) {
+  const header = lines[0]
+    .split("|")
+    .map((cell) => cell.trim())
+    .filter(Boolean);
+  const aligns = lines[1]
+    .split("|")
+    .map((cell) => cell.trim())
+    .filter(Boolean);
+  const rows = lines.slice(2).map((row) =>
+    row
+      .split("|")
+      .map((cell) => cell.trim())
+      .filter(Boolean)
+  );
+
+  let thead =
+    "<thead><tr>" +
+    header.map((h) => `<th>${h}</th>`).join("") +
+    "</tr></thead>";
+  let tbody =
+    "<tbody>" +
+    rows
+      .map((r) => "<tr>" + r.map((c) => `<td>${c}</td>`).join("") + "</tr>")
+      .join("") +
+    "</tbody>";
+
+  return `<table>${thead}${tbody}</table>`;
+}

--- a/js/utils/escapeHtml.js
+++ b/js/utils/escapeHtml.js
@@ -1,0 +1,8 @@
+export function escapeHtml(text) {
+  const map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+  };
+  return text.replace(/[&<>]/g, (char) => map[char]);
+}

--- a/simple_md.html
+++ b/simple_md.html
@@ -61,6 +61,19 @@
         padding: 0.2em 0.4em;
         font-family: monospace;
       }
+      .hl-tag {
+        color: #d73a49;
+      }
+      .hl-attr {
+        color: #6f42c1;
+      }
+      .hl-string {
+        color: #032f62;
+      }
+      .hl-comment {
+        color: #6a737d;
+        font-style: italic;
+      }
     </style>
   </head>
   <body>
@@ -68,176 +81,6 @@
       <textarea id="editor" placeholder="ここにMarkdownを入力"></textarea>
       <div id="preview"></div>
     </div>
-
-    <script>
-      const editor = document.getElementById("editor");
-      const preview = document.getElementById("preview");
-
-      editor.addEventListener("input", () => {
-        preview.innerHTML = parseMarkdown(editor.value);
-      });
-
-      function escapeHtml(text) {
-        const map = {
-          "&": "&amp;",
-          "<": "&lt;",
-          ">": "&gt;",
-        };
-        return text.replace(/[&<>]/g, (char) => map[char]);
-      }
-
-      function parseMarkdown(md) {
-        const lines = md.split(/\n/);
-        const out = [];
-        let inCodeBlock = false;
-        let codeBlockLang = "";
-        let inPre = false;
-        let tableBuffer = [];
-        let inList = false,
-          inOl = false;
-
-        for (let i = 0; i < lines.length; i++) {
-          let line = lines[i];
-
-          if (/^```|^~~~/.test(line)) {
-            inCodeBlock = !inCodeBlock;
-            if (inCodeBlock) {
-              out.push("<pre><code>");
-            } else {
-              out.push("</code></pre>");
-            }
-            continue;
-          }
-
-          if (inCodeBlock) {
-            out.push(escapeHtml(line));
-            continue;
-          }
-
-          if (/^\s{4,}/.test(line)) {
-            if (!inPre) {
-              out.push("<pre>");
-              inPre = true;
-            }
-            out.push(escapeHtml(line));
-            continue;
-          } else if (inPre) {
-            out.push("</pre>");
-            inPre = false;
-          }
-
-          if (/^\|.*\|$/.test(line)) {
-            tableBuffer.push(line);
-            continue;
-          } else if (tableBuffer.length > 0) {
-            out.push(renderTable(tableBuffer));
-            tableBuffer = [];
-          }
-
-          if (/^\s*$/.test(line)) {
-            out.push("<br>");
-            continue;
-          }
-
-          if (/^#{1,6} /.test(line)) {
-            const level = line.match(/^#+/)[0].length;
-            out.push(`<h${level}>${line.slice(level).trim()}</h${level}>`);
-            continue;
-          }
-
-          if (/^>+ /.test(line)) {
-            const level = line.match(/^>+/)[0].length;
-            line = line.replace(/^>+ /, "").trim();
-            out.push(`<blockquote>${line}</blockquote>`);
-            continue;
-          }
-
-          if (/^\*{3,}|-{3,}|_{3,}/.test(line)) {
-            out.push("<hr>");
-            continue;
-          }
-
-          if (/^\d+\. /.test(line)) {
-            if (!inOl) {
-              out.push("<ol>");
-              inOl = true;
-            }
-            out.push(`<li>${line.replace(/^\d+\. /, "")}</li>`);
-            continue;
-          } else if (inOl) {
-            out.push("</ol>");
-            inOl = false;
-          }
-
-          if (/^[-+*] /.test(line)) {
-            if (!inList) {
-              out.push("<ul>");
-              inList = true;
-            }
-            out.push(`<li>${line.replace(/^[-+*] /, "")}</li>`);
-            continue;
-          } else if (inList) {
-            out.push("</ul>");
-            inList = false;
-          }
-
-          // inline formatting
-          line = line
-            .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
-            .replace(/___(.+?)___/g, "<strong><em>$1</em></strong>")
-            .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-            .replace(/__(.+?)__/g, "<strong>$1</strong>")
-            .replace(/\*(.+?)\*/g, "<em>$1</em>")
-            .replace(/_(.+?)_/g, "<em>$1</em>")
-            .replace(/`(.+?)`/g, "<code>$1</code>")
-            .replace(/!\[(.*?)\]\((.*?)\)/g, '<img alt="$1" src="$2">')
-            .replace(
-              /\[(.*?)\]\((.*?)\)/g,
-              '<a href="$2" target="_blank">$1</a>'
-            );
-
-          out.push(`<p>${line}</p>`);
-        }
-
-        if (inPre) out.push("</pre>");
-        if (inList) out.push("</ul>");
-        if (inOl) out.push("</ol>");
-        if (tableBuffer.length > 0) out.push(renderTable(tableBuffer));
-
-        return out.join("\n");
-      }
-
-      function renderTable(lines) {
-        const header = lines[0]
-          .split("|")
-          .map((cell) => cell.trim())
-          .filter(Boolean);
-        const aligns = lines[1]
-          .split("|")
-          .map((cell) => cell.trim())
-          .filter(Boolean);
-        const rows = lines.slice(2).map((row) =>
-          row
-            .split("|")
-            .map((cell) => cell.trim())
-            .filter(Boolean)
-        );
-
-        let thead =
-          "<thead><tr>" +
-          header.map((h) => `<th>${h}</th>`).join("") +
-          "</tr></thead>";
-        let tbody =
-          "<tbody>" +
-          rows
-            .map(
-              (r) => "<tr>" + r.map((c) => `<td>${c}</td>`).join("") + "</tr>"
-            )
-            .join("") +
-          "</tbody>";
-
-        return `<table>${thead}${tbody}</table>`;
-      }
-    </script>
+    <script type="module" src="js/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- detect language hints on fenced code blocks
- add HTML tokenizer and styling for syntax highlighting
- move parsing and highlighting logic into dedicated modules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892ac05b0448325be016f619031e76a