### PR TITLE
Highlight JavaScript code blocks

### DIFF
--- a/style.css
+++ b/style.css
@@ -55,3 +55,18 @@ code {
   padding: 0.2em 0.4em;
   font-family: monospace;
 }
+
+.js-keyword {
+  color: #0000ff;
+  font-weight: bold;
+}
+.js-string {
+  color: #a31515;
+}
+.js-comment {
+  color: #008000;
+  font-style: italic;
+}
+.js-number {
+  color: #09885a;
+}


### PR DESCRIPTION
## Summary
- Parse fenced code blocks, detect language, buffer contents, and highlight JavaScript snippets.
- Add `highlightJavaScript` to escape HTML and wrap keywords, strings, comments, and numbers with spans.
- Style highlighted JavaScript tokens for keywords, strings, comments, and numbers.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6892ef2de7ac8325a4a25c60e648a1a6