### PR TITLE
refactor: extract JS syntax highlighting

### DIFF
--- a/highlight.js
+++ b/highlight.js
@@ -1,0 +1,24 @@
+// JavaScript syntax highlighting helper
+function highlightJsSyntax(code) {
+  code = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  const keywordPattern = `\\b(?:function|const|let|var|if|else|return|for|while|do|switch|case|break|continue)\\b`;
+  const regex = new RegExp(
+    `(".*?")|('.*?')|(\\/\\/.*)|(\\/\\*[\\s\\S]*?\\*\\/)|(${keywordPattern})|(\\b\\d+\\b)|(\\b[a-zA-Z_]\\w*(?=\\s*\\())`,
+    "g"
+  );
+
+  return code.replace(
+    regex,
+    (match, string1, string2, comment1, comment2, keyword, number, funcName) => {
+      if (string1 || string2) return `<span class="string">${match}</span>`;
+      if (comment1 || comment2) return `<span class="comment">${match}</span>`;
+      if (keyword) return `<span class="keyword">${match}</span>`;
+      if (number) return `<span class="number">${match}</span>`;
+      if (funcName) return `<span class="function-name">${match}</span>`;
+      return match;
+    }
+  );
+}
+
+window.highlightJsSyntax = highlightJsSyntax;

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
       <textarea id="editor" placeholder="ここにMarkdownを入力"></textarea>
       <div id="preview"></div>
     </div>
+    <script src="highlight.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/markdown_text.md
+++ b/markdown_text.md
@@ -1,0 +1,11 @@
+# Sample Markdown
+
+This is a test of the JavaScript syntax highlighting.
+
+```js
+// Add two numbers
+function add(a, b) {
+  return a + b;
+}
+```
+

--- a/script.js
+++ b/script.js
@@ -14,29 +14,6 @@ function escapeHtml(text) {
   return text.replace(/[&<>]/g, (char) => map[char]);
 }
 
-// JavaScriptの構文をハイライトする
-function highlightJsSyntax(code) {
-  code = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-
-  const keywordPattern = `\\b(?:function|const|let|var|if|else|return|for|while|do|switch|case|break|continue)\\b`;
-  const regex = new RegExp(
-    `(".*?")|('.*?')|(\\/\\/.*)|(\\/\\*[\\s\\S]*?\\*\\/)|(${keywordPattern})|(\\b\\d+\\b)|(\\b[a-zA-Z_]\\w*(?=\\s*\\())`,
-    "g"
-  );
-
-  return code.replace(
-    regex,
-    (match, string1, string2, comment1, comment2, keyword, number, funcName) => {
-      if (string1 || string2) return `<span class="string">${match}</span>`;
-      if (comment1 || comment2) return `<span class="comment">${match}</span>`;
-      if (keyword) return `<span class="keyword">${match}</span>`;
-      if (number) return `<span class="number">${match}</span>`;
-      if (funcName) return `<span class="function-name">${match}</span>`;
-      return match;
-    }
-  );
-}
-
 // 強調、コード、画像、リンクなどのインラインMarkdown機能を適用する。
 function applyInlineFormatting(text) {
   return (


### PR DESCRIPTION
## Summary
- isolate JavaScript code block highlighting into its own file
- load highlighting script in HTML
- add sample markdown for testing

## Testing
- `node --check script.js highlight.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68944d6267208325aa00ce705b0d7367