### PR TITLE
feat: Apply Bootstrap to Markdown Editor UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,14 +2,29 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <title>手動実装 Markdown Editor</title>
+    <title>Bootstrap対応 Markdown Editor</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div class="container">
-      <textarea id="editor" placeholder="ここにMarkdownを入力"></textarea>
-      <div id="preview"></div>
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-md-6">
+          <textarea
+            id="editor"
+            class="form-control"
+            placeholder="ここにMarkdownを入力"
+          ></textarea>
+        </div>
+        <div class="col-md-6">
+          <div id="preview"></div>
+        </div>
+      </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -315,5 +315,5 @@ function renderTable(lines) {
       .join("") +
     "</tbody>";
 
-  return `<table>${thead}${tbody}</table>`;
+  return `<table class="table table-bordered">${thead}${tbody}</table>`;
 }

--- a/style.css
+++ b/style.css
@@ -1,59 +1,50 @@
 body {
-  display: flex;
-  flex-direction: column;
   font-family: sans-serif;
   margin: 0;
   padding: 0;
 }
-textarea {
-  width: 50%;
-  height: 100vh;
-  padding: 1em;
-  border: none;
-  font-family: monospace;
-  font-size: 1em;
-}
+
+/* Make editor and preview full height */
+#editor,
 #preview {
-  width: 50%;
-  height: 100vh;
+  height: calc(100vh - 20px);
   overflow: auto;
+}
+
+/* Remove default textarea border and resize handle from bootstrap's form-control */
+#editor {
+  border-radius: 0;
+  resize: none;
+}
+
+#preview {
   padding: 1em;
-  border-left: 1px solid #ccc;
+  /* border-left is handled by bootstrap col separation, but let's add a subtle one */
+  border-left: 1px solid #dee2e6;
 }
-.container {
-  display: flex;
-}
+
 pre {
-  background-color: #f0f0f0;
-  padding: 0.5em;
+  background-color: #f8f9fa; /* Lighter gray */
+  padding: 1em;
+  border-radius: 0.25rem;
 }
 blockquote {
-  border-left: 4px solid #aaa;
-  padding-left: 1em;
-  color: #666;
+  border-left: 0.25rem solid #e9ecef;
+  padding-left: 1rem;
+  color: #6c757d; /* Bootstrap muted color */
+  margin-left: 0;
 }
 hr {
   border: none;
   border-top: 1px solid #ccc;
   margin: 1em 0;
 }
-table {
-  border-collapse: collapse;
-  width: 100%;
-}
-table,
-th,
-td {
-  border: 1px solid #ccc;
-}
-th,
-td {
-  padding: 0.5em;
-}
+
 code {
-  background: #f4f4f4;
+  background: #f8f9fa;
   padding: 0.2em 0.4em;
   font-family: monospace;
+  border-radius: 3px;
 }
 
 /* Syntax Highlighting Styles */


### PR DESCRIPTION
Refactor the UI of the Markdown editor to use Bootstrap 5.

This change introduces Bootstrap to create a more modern and responsive two-pane layout for the editor and preview.

- Updates `index.html` to include the Bootstrap 5 CDN and uses the Bootstrap grid system for layout.
- Replaces the previous flexbox-based layout with a `container-fluid` and `row`/`col` structure.
- Adds the `form-control` class to the editor's `textarea`.
- Cleans up `style.css` by removing layout styles now handled by Bootstrap and adjusts other styles to better align with the Bootstrap look and feel.
- Modifies `script.js` to add `table` and `table-bordered` classes to the Markdown-generated tables, ensuring they are styled correctly by Bootstrap.