### PR TITLE
Remove invalid list markup from HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,27 +27,8 @@
       </div>
     </div>
 
-
-
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-
-
     <script src="highlight.js"></script>
-
-    <!-- list 階層 test -->
-    <div>
-      <lu>
-        <li>
-          ::marker
-          <li>
-::marker
-          </li>
-          </li>
-          </lu>
-    </div>
-
-
-
     <script src="script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove stray test `<div>` and `<lu>` list from `index.html`
- keep only textarea, preview and script tags

## Testing
- `python -m http.server 8000` then `curl -s http://localhost:8000/ | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_689986190f588325b6bcd277a42d33b5