### PR TITLE
Refactor markdown rendering into reusable function

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,25 +1,24 @@
 const editor = document.getElementById("editor");
 const preview = document.getElementById("preview");
 
-// Set marked.js options for GFM compatibility
-marked.setOptions({
-  breaks: true, // GFM-style line breaks
-  gfm: true,
-});
+function renderMarkdown(text) {
+  // Set marked.js options for GFM compatibility
+  marked.setOptions({
+    breaks: true, // GFM-style line breaks
+    gfm: true,
+  });
 
-
-editor.addEventListener("input", () => {
-  const markdownText = editor.value;
-  const rawHtml = marked.parse(markdownText);
+  const rawHtml = marked.parse(text);
   const sanitizedHtml = DOMPurify.sanitize(rawHtml);
   preview.innerHTML = sanitizedHtml;
+}
+
+editor.addEventListener("input", () => {
+  renderMarkdown(editor.value);
 });
 
 // Initial render on page load
-const initialMarkdown = editor.value;
-const rawHtml = marked.parse(initialMarkdown);
-const sanitizedHtml = DOMPurify.sanitize(rawHtml);
-preview.innerHTML = sanitizedHtml;
+renderMarkdown(editor.value);
 
 function escapeHtml(text) {
   const map = {


### PR DESCRIPTION
## Summary
- Move markdown parsing and sanitization into `renderMarkdown(text)`
- Invoke `renderMarkdown` for editor input and initial page load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689986faf57c8325bb4dd984f75d55c3