### PR TITLE
Refactor markdown rendering into reusable function

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,12 @@
 const editor = document.getElementById("editor");
 const preview = document.getElementById("preview");
 
+function renderMarkdown(text) {
+  const rawHtml = marked.parse(text);
+  const sanitizedHtml = DOMPurify.sanitize(rawHtml);
+  preview.innerHTML = sanitizedHtml;
+}
+
 // Set marked.js options for GFM compatibility and syntax highlighting
 marked.setOptions({
   breaks: true, // GFM-style line breaks
@@ -12,16 +18,9 @@ marked.setOptions({
   },
 });
 
-editor.addEventListener("input", () => {
-  const markdownText = editor.value;
-  const rawHtml = marked.parse(markdownText);
-  const sanitizedHtml = DOMPurify.sanitize(rawHtml);
-  preview.innerHTML = sanitizedHtml;
-});
+renderMarkdown(editor.value);
 
-// Initial render on page load
-const initialMarkdown = editor.value;
-const rawHtml = marked.parse(initialMarkdown);
-const sanitizedHtml = DOMPurify.sanitize(rawHtml);
-preview.innerHTML = sanitizedHtml;
+editor.addEventListener("input", () => {
+  renderMarkdown(editor.value);
+});
 


### PR DESCRIPTION
## Summary
- add `renderMarkdown` helper to handle marked parsing and DOMPurify sanitization
- invoke `renderMarkdown` for initial preview and on every input event

## Testing
- `node test_env/test_render.js`

------
https://chatgpt.com/codex/tasks/task_e_6899d7aa63a8832592b7cc0f7d2d632d