### PR TITLE
Support nested lists in markdown parser

### DIFF
--- a/markdown_text.md
+++ b/markdown_text.md
@@ -9,3 +9,12 @@ function add(a, b) {
 }
 ```
 
+- Fruits
+  - Apple
+  - Banana
+    1. Cavendish
+    2. Plantain
+- Vegetables
+  1. Carrot
+  2. Broccoli
+

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { parseMarkdown } = require('./app');
+
+const md = `- Fruits
+  - Apple
+  - Banana
+    1. Cavendish
+    2. Plantain
+- Vegetables
+  1. Carrot
+  2. Broccoli`;
+
+const expected = '<ul><li>Fruits<ul><li>Apple</li><li>Banana<ol><li>Cavendish</li><li>Plantain</li></ol></li></ul></li><li>Vegetables<ol><li>Carrot</li><li>Broccoli</li></ol></li></ul>';
+
+const output = parseMarkdown(md);
+assert.strictEqual(output, expected);
+
+console.log('Nested list parsing test passed.');


### PR DESCRIPTION
## Summary
- handle list indentation by maintaining a stack of open lists
- export parser for Node and add test verifying nested lists
- include sample nested list in documentation markdown

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689d46bc15a083259adb389bc7f23b6d