### PR TITLE
Support paragraphs and Markdown line breaks

### DIFF
--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -16,3 +16,13 @@ const output = parseMarkdown(md);
 assert.strictEqual(output, expected);
 
 console.log('Nested list parsing test passed.');
+
+const paragraphsMd = `First paragraph\n\nSecond paragraph`;
+const paragraphsExpected = '<p>First paragraph</p><p>Second paragraph</p>';
+assert.strictEqual(parseMarkdown(paragraphsMd), paragraphsExpected);
+console.log('Paragraph splitting test passed.');
+
+const lineBreakMd = `Line one  \nLine two`;
+const lineBreakExpected = '<p>Line one<br>Line two</p>';
+assert.strictEqual(parseMarkdown(lineBreakMd), lineBreakExpected);
+console.log('Line break conversion test passed.');


### PR DESCRIPTION
## Summary
- Group lines into paragraphs and insert `<br>` on two-space line endings
- Add tests for paragraph splitting and line break conversion

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5291efe808325a231cf81b688bd10