### PR TITLE
feat: support nested blockquotes

### DIFF
--- a/app.js
+++ b/app.js
@@ -88,9 +88,12 @@ function parseMarkdown(markdown) {
       return;
     }
 
-    if (/^> /.test(line)) {
+    const bqMatch = line.match(/^(>+)\s*/);
+    if (bqMatch) {
       flushParagraph();
-      html += `<blockquote>${sanitize(line.slice(2))}</blockquote>`;
+      const depth = bqMatch[1].length;
+      const content = sanitize(line.slice(bqMatch[0].length));
+      html += '<blockquote>'.repeat(depth) + content + '</blockquote>'.repeat(depth);
       return;
     }
 

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -26,3 +26,8 @@ const lineBreakMd = `Line one  \nLine two`;
 const lineBreakExpected = '<p>Line one<br>Line two</p>';
 assert.strictEqual(parseMarkdown(lineBreakMd), lineBreakExpected);
 console.log('Line break conversion test passed.');
+
+const blockquoteMd = `>>> Nested quote`;
+const blockquoteExpected = '<blockquote><blockquote><blockquote>Nested quote</blockquote></blockquote></blockquote>';
+assert.strictEqual(parseMarkdown(blockquoteMd), blockquoteExpected);
+console.log('Nested blockquote parsing test passed.');


### PR DESCRIPTION
## Summary
- handle multiple leading `>` for nested blockquotes
- add test for nested blockquotes

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a52ad7dd408325b6643e993c0291de