### PR TITLE
Support code blocks delimited by backticks and tildes

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ function parseMarkdown(markdown) {
   const lines = markdown.split(/\r?\n/);
   let html = '';
   let inCode = false;
+  let codeDelimiter = null;
   const listStack = [];
   let paragraph = '';
 
@@ -26,14 +27,20 @@ function parseMarkdown(markdown) {
   };
 
   lines.forEach((line) => {
-    if (line.trim().startsWith('```')) {
+    const trimmedLine = line.trim();
+    if (trimmedLine.startsWith('```') || trimmedLine.startsWith('~~~')) {
       flushParagraph();
-      if (inCode) {
+      const delimiter = trimmedLine.slice(0, 3);
+      if (inCode && delimiter === codeDelimiter) {
         html += '</code></pre>';
         inCode = false;
-      } else {
+        codeDelimiter = null;
+      } else if (!inCode) {
         html += '<pre><code>';
         inCode = true;
+        codeDelimiter = delimiter;
+      } else {
+        html += sanitize(line) + '\n';
       }
       return;
     }

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -31,3 +31,13 @@ const blockquoteMd = `>>> Nested quote`;
 const blockquoteExpected = '<blockquote><blockquote><blockquote>Nested quote</blockquote></blockquote></blockquote>';
 assert.strictEqual(parseMarkdown(blockquoteMd), blockquoteExpected);
 console.log('Nested blockquote parsing test passed.');
+
+const backtickCodeBlockMd = '```\ncode\n```';
+const backtickCodeBlockExpected = '<pre><code>code\n</code></pre>';
+assert.strictEqual(parseMarkdown(backtickCodeBlockMd), backtickCodeBlockExpected);
+console.log('Backtick code block parsing test passed.');
+
+const tildeCodeBlockMd = '~~~\ncode\n~~~';
+const tildeCodeBlockExpected = '<pre><code>code\n</code></pre>';
+assert.strictEqual(parseMarkdown(tildeCodeBlockMd), tildeCodeBlockExpected);
+console.log('Tilde code block parsing test passed.');


### PR DESCRIPTION
## Summary
- Allow `parseMarkdown` to handle fenced code blocks starting with either triple backticks or triple tildes
- Track and match code block delimiters to properly open and close fenced sections
- Add tests verifying code block parsing for both ` ``` ` and ` ~~~ ` delimiters

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a52ba5b35c832584b872c98fd8226a