### PR TITLE
test: add inline code conversion test

### DIFF
--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -41,3 +41,8 @@ const tildeCodeBlockMd = '~~~\ncode\n~~~';
 const tildeCodeBlockExpected = '<pre><code>code\n</code></pre>';
 assert.strictEqual(parseMarkdown(tildeCodeBlockMd), tildeCodeBlockExpected);
 console.log('Tilde code block parsing test passed.');
+
+const inlineCodeMd = 'This has `code` inline';
+const inlineCodeExpected = '<p>This has <code>code</code> inline</p>';
+assert.strictEqual(parseMarkdown(inlineCodeMd), inlineCodeExpected);
+console.log('Inline code conversion test passed.');


### PR DESCRIPTION
## Summary
- add test verifying backtick-wrapped text converts to `<code>`

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a52cd2cc848325951a38903e665f7b