### PR TITLE
Support additional horizontal rule syntax

### DIFF
--- a/app.js
+++ b/app.js
@@ -132,7 +132,7 @@ function parseMarkdown(markdown) {
       return;
     }
 
-    if (/^---$/.test(line.trim())) {
+    if (/^(?:---|\*\*\*|___)$/.test(line.trim())) {
       flushParagraph();
       html += '<hr />';
       return;

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -32,6 +32,21 @@ const blockquoteExpected = '<blockquote><blockquote><blockquote>Nested quote</bl
 assert.strictEqual(parseMarkdown(blockquoteMd), blockquoteExpected);
 console.log('Nested blockquote parsing test passed.');
 
+const hrDashMd = '---';
+const hrDashExpected = '<hr />';
+assert.strictEqual(parseMarkdown(hrDashMd), hrDashExpected);
+console.log('Horizontal rule (dash) test passed.');
+
+const hrAsteriskMd = '***';
+const hrAsteriskExpected = '<hr />';
+assert.strictEqual(parseMarkdown(hrAsteriskMd), hrAsteriskExpected);
+console.log('Horizontal rule (asterisk) test passed.');
+
+const hrUnderscoreMd = '___';
+const hrUnderscoreExpected = '<hr />';
+assert.strictEqual(parseMarkdown(hrUnderscoreMd), hrUnderscoreExpected);
+console.log('Horizontal rule (underscore) test passed.');
+
 const backtickCodeBlockMd = '```\ncode\n```';
 const backtickCodeBlockExpected = '<pre><code>code\n</code></pre>';
 assert.strictEqual(parseMarkdown(backtickCodeBlockMd), backtickCodeBlockExpected);


### PR DESCRIPTION
## Summary
- Parse `***` and `___` as horizontal rules
- Test horizontal rule parsing for dash, asterisk, and underscore variants

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a531e0521883258a7e078b9e4c2dcd