### PR TITLE
Add '+' unordered list marker and tests for list markers

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,14 +68,14 @@ function parseMarkdown(markdown) {
 
     const indentSpaces = line.match(/^ */)[0].length;
     const trimmed = line.trimStart();
-    const ulMatch = /^[-*] /.test(trimmed);
+    const ulMatch = /^[-*+] /.test(trimmed);
     const olMatch = /^[0-9]+\. /.test(trimmed);
 
     if (ulMatch || olMatch) {
       flushParagraph();
       const type = ulMatch ? 'ul' : 'ol';
       const content = ulMatch
-        ? trimmed.replace(/^[-*] /, '')
+        ? trimmed.replace(/^[-*+] /, '')
         : trimmed.replace(/^[0-9]+\. /, '');
       const depth = Math.floor(indentSpaces / 2) + 1;
 

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -71,3 +71,18 @@ const tabCodeMd = '\tline1\n\tline2';
 const tabCodeExpected = '<pre><code>line1\nline2\n</code></pre>';
 assert.strictEqual(parseMarkdown(tabCodeMd), tabCodeExpected);
 console.log('Indented code block (tab) parsing test passed.');
+
+const dashListMd = '- Item';
+const dashListExpected = '<ul><li>Item</li></ul>';
+assert.strictEqual(parseMarkdown(dashListMd), dashListExpected);
+console.log('Dash list marker test passed.');
+
+const starListMd = '* Item';
+const starListExpected = '<ul><li>Item</li></ul>';
+assert.strictEqual(parseMarkdown(starListMd), starListExpected);
+console.log('Asterisk list marker test passed.');
+
+const plusListMd = '+ Item';
+const plusListExpected = '<ul><li>Item</li></ul>';
+assert.strictEqual(parseMarkdown(plusListMd), plusListExpected);
+console.log('Plus list marker test passed.');


### PR DESCRIPTION
## Summary
- support '+' as unordered list marker in markdown parser
- add tests ensuring '-', '*', '+' markers generate lists

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a53400e63c8325a3327fe5cb5cb3b4