### PR TITLE
Support underscore emphasis in Markdown parser

### DIFF
--- a/app.js
+++ b/app.js
@@ -158,8 +158,8 @@ function parseMarkdown(markdown) {
     }
 
     let processed = sanitize(line).trimEnd();
-    processed = processed.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-    processed = processed.replace(/\*(.+?)\*/g, '<em>$1</em>');
+    processed = processed.replace(/(\*\*|__)(.+?)\1/g, '<strong>$2</strong>');
+    processed = processed.replace(/(\*|_)(.+?)\1/g, '<em>$2</em>');
     processed = processed.replace(/`([^`]+)`/g, '<code>$1</code>');
     processed = processed.replace(/\[(.+?)\]\((.+?)\)/g, (m, text, url) => `<a href="${url}">${text}</a>`);
     processed = processed.replace(/\[(.+?)\]\[(.+?)\]/g, (m, text, id) => {

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -106,3 +106,23 @@ const refLinkMd = `[text][id]\n\n[id]: url`;
 const refLinkExpected = '<p><a href="url">text</a></p>';
 assert.strictEqual(parseMarkdown(refLinkMd), refLinkExpected);
 console.log('Reference link conversion test passed.');
+
+const emStarMd = '*italic*';
+const emStarExpected = '<p><em>italic</em></p>';
+assert.strictEqual(parseMarkdown(emStarMd), emStarExpected);
+console.log('Asterisk emphasis test passed.');
+
+const emUnderscoreMd = '_italic_';
+const emUnderscoreExpected = '<p><em>italic</em></p>';
+assert.strictEqual(parseMarkdown(emUnderscoreMd), emUnderscoreExpected);
+console.log('Underscore emphasis test passed.');
+
+const strongStarMd = '**bold**';
+const strongStarExpected = '<p><strong>bold</strong></p>';
+assert.strictEqual(parseMarkdown(strongStarMd), strongStarExpected);
+console.log('Double asterisk strong test passed.');
+
+const strongUnderscoreMd = '__bold__';
+const strongUnderscoreExpected = '<p><strong>bold</strong></p>';
+assert.strictEqual(parseMarkdown(strongUnderscoreMd), strongUnderscoreExpected);
+console.log('Double underscore strong test passed.');


### PR DESCRIPTION
## Summary
- allow both asterisks and underscores to generate `<em>` and `<strong>` elements
- add unit tests covering emphasis and strong markers with `*`, `_`, `**`, and `__`

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a53a6c41bc832584390df97de49795