### PR TITLE
Handle composite emphasis in parser

### DIFF
--- a/app.js
+++ b/app.js
@@ -158,6 +158,7 @@ function parseMarkdown(markdown) {
     }
 
     let processed = sanitize(line).trimEnd();
+    processed = processed.replace(/(\*\*\*|___)(.+?)\1/g, '<strong><em>$2</em></strong>');
     processed = processed.replace(/(\*\*|__)(.+?)\1/g, '<strong>$2</strong>');
     processed = processed.replace(/(\*|_)(.+?)\1/g, '<em>$2</em>');
     processed = processed.replace(/`([^`]+)`/g, '<code>$1</code>');

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -126,3 +126,13 @@ const strongUnderscoreMd = '__bold__';
 const strongUnderscoreExpected = '<p><strong>bold</strong></p>';
 assert.strictEqual(parseMarkdown(strongUnderscoreMd), strongUnderscoreExpected);
 console.log('Double underscore strong test passed.');
+
+const strongEmStarMd = '***both***';
+const strongEmStarExpected = '<p><strong><em>both</em></strong></p>';
+assert.strictEqual(parseMarkdown(strongEmStarMd), strongEmStarExpected);
+console.log('Triple asterisk strong and emphasis test passed.');
+
+const strongEmUnderscoreMd = '___both___';
+const strongEmUnderscoreExpected = '<p><strong><em>both</em></strong></p>';
+assert.strictEqual(parseMarkdown(strongEmUnderscoreMd), strongEmUnderscoreExpected);
+console.log('Triple underscore strong and emphasis test passed.');


### PR DESCRIPTION
## Summary
- support combined strong+em using *** or ___ markers
- cover ***text*** and ___text___ with tests

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a548750ae8832596607d06944e1e5a