### PR TITLE
Add image markdown parsing

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,6 +162,7 @@ function parseMarkdown(markdown) {
     processed = processed.replace(/(\*\*|__)(.+?)\1/g, '<strong>$2</strong>');
     processed = processed.replace(/(\*|_)(.+?)\1/g, '<em>$2</em>');
     processed = processed.replace(/`([^`]+)`/g, '<code>$1</code>');
+    processed = processed.replace(/!\[(.+?)\]\((.+?)\)/g, (m, alt, url) => `<img src="${url}" alt="${alt}" />`);
     processed = processed.replace(/\[(.+?)\]\((.+?)\)/g, (m, text, url) => `<a href="${url}">${text}</a>`);
     processed = processed.replace(/\[(.+?)\]\[(.+?)\]/g, (m, text, id) => {
       const url = refLinks[id.toLowerCase()];

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -107,6 +107,11 @@ const refLinkExpected = '<p><a href="url">text</a></p>';
 assert.strictEqual(parseMarkdown(refLinkMd), refLinkExpected);
 console.log('Reference link conversion test passed.');
 
+const imageMd = '![alt](url)';
+const imageExpected = '<p><img src="url" alt="alt" /></p>';
+assert.strictEqual(parseMarkdown(imageMd), imageExpected);
+console.log('Image conversion test passed.');
+
 const emStarMd = '*italic*';
 const emStarExpected = '<p><em>italic</em></p>';
 assert.strictEqual(parseMarkdown(emStarMd), emStarExpected);


### PR DESCRIPTION
## Summary
- convert `![alt](url)` syntax into `<img>` tags in `parseMarkdown`
- test image markdown parsing

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5564d99d483259f2831e9749385c6