### PR TITLE
Separate styles for inline and block code elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,10 +29,17 @@ pre {
   overflow: auto;
 }
 
-code {
+code:not(pre code) {
   background: #f4f4f4;
   padding: 0.2em 0.4em;
   border-radius: 3px;
+}
+
+pre code {
+  background: #f4f4f4;
+  padding: 0;
+  border-radius: 0;
+  display: block;
 }
 
 blockquote {


### PR DESCRIPTION
## Summary
- Restrict `code` rule to inline elements using `code:not(pre code)`
- Add `pre code` rule to style block code blocks and override inline defaults

## Testing
- `node parseMarkdown.test.js`
- `node -e "const { parseMarkdown } = require('./app'); const md='Here is \`inline\` code\n\n\`\`\`\nblock\ncode\n\`\`\`'; console.log(parseMarkdown(md));"`

------
https://chatgpt.com/codex/tasks/task_e_68a56be75f988325a116bf09c095c54c