### PR TITLE
Add language support to fenced code blocks

### DIFF
--- a/app.js
+++ b/app.js
@@ -124,7 +124,8 @@ function parseMarkdown(markdown) {
         inCode = false;
         codeDelimiter = null;
       } else if (!inCode) {
-        html += '<pre><code>';
+        const lang = trimmedLine.slice(3).trim();
+        html += `<pre><code class="language-${lang}" data-tokenized="0">`;
         inCode = true;
         codeDelimiter = delimiter;
       } else {

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -48,14 +48,19 @@ assert.strictEqual(parseMarkdown(hrUnderscoreMd), hrUnderscoreExpected);
 console.log('Horizontal rule (underscore) test passed.');
 
 const backtickCodeBlockMd = '```\ncode\n```';
-const backtickCodeBlockExpected = '<pre><code>code\n</code></pre>';
+const backtickCodeBlockExpected = '<pre><code class="language-" data-tokenized="0">code\n</code></pre>';
 assert.strictEqual(parseMarkdown(backtickCodeBlockMd), backtickCodeBlockExpected);
 console.log('Backtick code block parsing test passed.');
 
 const tildeCodeBlockMd = '~~~\ncode\n~~~';
-const tildeCodeBlockExpected = '<pre><code>code\n</code></pre>';
+const tildeCodeBlockExpected = '<pre><code class="language-" data-tokenized="0">code\n</code></pre>';
 assert.strictEqual(parseMarkdown(tildeCodeBlockMd), tildeCodeBlockExpected);
 console.log('Tilde code block parsing test passed.');
+
+const langCodeBlockMd = '```javascript\nconsole.log(1);\n```';
+const langCodeBlockExpected = '<pre><code class="language-javascript" data-tokenized="0">console.log(1);\n</code></pre>';
+assert.strictEqual(parseMarkdown(langCodeBlockMd), langCodeBlockExpected);
+console.log('Language code fence parsing test passed.');
 
 const inlineCodeMd = 'This has `code` inline';
 const inlineCodeExpected = '<p>This has <code>code</code> inline</p>';


### PR DESCRIPTION
## Summary
- Enhance fenced code block parsing to capture language identifiers and emit `<code>` tags with `language-<lang>` classes and `data-tokenized="0"` attribute.
- Extend tests to validate language extraction and updated output format for fenced code blocks.

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a67624f64c8325b74006dc09d2baaf