### PR TITLE
Add syntax highlighting themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <title>Markdown Editor</title>
     <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="syntax_highlight.css" />
   </head>
   <body>
     <div class="container">

--- a/syntax_highlight.css
+++ b/syntax_highlight.css
@@ -1,0 +1,61 @@
+:root {
+  --code-bg: #1e1e1e;
+  --code-txt: #d4d4d4;
+  --kw: #c586c0;
+  --type: #4ec9b0;
+  --str: #ce9178;
+  --num: #b5cea8;
+  --com: #6a9955;
+  --func: #dcdcaa;
+}
+
+pre, code {
+  background: var(--code-bg);
+  color: var(--code-txt);
+}
+
+.tok-keyword {
+  color: var(--kw);
+}
+
+.tok-type {
+  color: var(--type);
+}
+
+.tok-string {
+  color: var(--str);
+}
+
+.tok-number {
+  color: var(--num);
+}
+
+.tok-comment {
+  color: var(--com);
+}
+
+.tok-function {
+  color: var(--func);
+}
+
+[data-theme="light"] {
+  --code-bg: #f5f5f5;
+  --code-txt: #333;
+  --kw: #0000ff;
+  --type: #267f99;
+  --str: #a31515;
+  --num: #098658;
+  --com: #008000;
+  --func: #795e26;
+}
+
+[data-theme="high-contrast"] {
+  --code-bg: #000;
+  --code-txt: #fff;
+  --kw: #ff9aff;
+  --type: #a4ffff;
+  --str: #ffb977;
+  --num: #ffff00;
+  --com: #ffffff;
+  --func: #00ff00;
+}


### PR DESCRIPTION
## Summary
- add dedicated syntax_highlight.css with theme variables and token colors
- include optional light and high-contrast overrides
- load syntax highlighting stylesheet in index.html

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a679084c8c832591b83083059de3e3