### PR TITLE
Add Java syntax tokenizer tests and fix operator regex

### DIFF
--- a/codeBlockSyntax_java.js
+++ b/codeBlockSyntax_java.js
@@ -16,7 +16,7 @@
   function tokenizeJava(code){
     const keywordRe = /^(?:abstract|assert|boolean|break|byte|case|catch|char|class|const|continue|default|do|double|else|enum|extends|final|finally|float|for|if|goto|implements|import|instanceof|int|interface|long|native|new|package|private|protected|public|return|short|static|strictfp|super|switch|synchronized|this|throw|throws|transient|try|void|volatile|while|record)\b/;
     const numberRe = /^(?:0[xX][0-9a-fA-F_]+|0[bB][01_]+|\d[\d_]*(?:\.\d[\d_]*)?(?:[eE][+-]?\d[\d_]*)?)[lLfFdD]?/;
-    const operatorRe = /^(?:==|!=|<=|>=|\+\+|--|&&|\|\||<<=|>>=|>>>|<<|>>|::|->|\+=|-=|\*=|/=|%=|&=|\|=|\^=|[+\-*/%&|^!~<>=?:])/;
+    const operatorRe = /^(?:==|!=|<=|>=|\+\+|--|&&|\|\||<<=|>>=|>>>|<<|>>|::|->|\+=|-=|\*=|\/=|%=|&=|\|=|\^=|[+\-*/%&|^!~<>=?:])/;
     const punctRe = /^[(){}\[\],.;]/;
     let html = '';
     let i = 0;

--- a/codeBlockSyntax_java.test.js
+++ b/codeBlockSyntax_java.test.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+const { tokenizeJava } = require('./codeBlockSyntax_java');
+
+// Basic class and method tokenization
+let output = tokenizeJava(
+  'class Hello { public static void main(String[] args) { System.out.println("Hi"); } }'
+);
+assert(output.includes('<span class="tok tok-keyword">class</span>'));
+assert(output.includes('<span class="tok tok-class">Hello</span>'));
+assert(output.includes('<span class="tok tok-keyword">public</span>'));
+assert(output.includes('<span class="tok tok-keyword">static</span>'));
+assert(output.includes('<span class="tok tok-keyword">void</span>'));
+assert(output.includes('<span class="tok tok-method">main</span>'));
+console.log('Basic Java tokenization test passed.');
+
+// Annotation handling
+output = tokenizeJava(
+  'class Hello { @Override public String toString() { return "Hi"; } }'
+);
+assert(output.includes('<span class="tok tok-annotation">@Override</span>'));
+console.log('Annotation tokenization test passed.');
+
+// Record declaration
+output = tokenizeJava('record Person(String name, int age) {}');
+assert(output.includes('<span class="tok tok-keyword">record</span>'));
+assert(output.includes('<span class="tok tok-class">Person</span>'));
+console.log('Record tokenization test passed.');
+
+// Comment styles
+output = tokenizeJava('// line comment');
+assert(output.includes('<span class="tok tok-comment">// line comment</span>'));
+output = tokenizeJava('/* block comment */');
+assert(output.includes('<span class="tok tok-comment">/* block comment */</span>'));
+console.log('Comment tokenization test passed.');
+
+// Numeric literals
+output = tokenizeJava('int x = 0xFF; double y = 3.14e10;');
+assert(output.includes('<span class="tok tok-number">0xFF</span>'));
+assert(output.includes('<span class="tok tok-number">3.14e10</span>'));
+console.log('Numeric literal tokenization test passed.');


### PR DESCRIPTION
## Summary
- add comprehensive tests for Java code block tokenization including classes, annotations, records, comments and numeric literals
- fix Java tokenizer's operator regex to properly escape division assignment

## Testing
- `node codeBlockSyntax_java.test.js`
- `node parseMarkdown.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a67cac3c7483259846c8c798a05c27