### PR TITLE
Escape quotes in sanitizer and tokenize safely

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,9 @@ function sanitize(str) {
   return str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function parseMarkdown(markdown) {
@@ -291,5 +293,5 @@ if (typeof document !== 'undefined') {
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = { parseMarkdown };
+  module.exports = { parseMarkdown, sanitize };
 }

--- a/codeBlockSyntax_java.js
+++ b/codeBlockSyntax_java.js
@@ -2,7 +2,15 @@
   const languages = {};
 
   function escapeHtml(str){
-    return str.replace(/&/g, '&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    if (typeof sanitize === 'function'){
+      return sanitize(str);
+    }
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
   }
 
   function wrap(type, text){
@@ -16,7 +24,7 @@
   function tokenizeJava(code){
     const keywordRe = /^(?:abstract|assert|boolean|break|byte|case|catch|char|class|const|continue|default|do|double|else|enum|extends|final|finally|float|for|if|goto|implements|import|instanceof|int|interface|long|native|new|package|private|protected|public|return|short|static|strictfp|super|switch|synchronized|this|throw|throws|transient|try|void|volatile|while|record)\b/;
     const numberRe = /^(?:0[xX][0-9a-fA-F_]+|0[bB][01_]+|\d[\d_]*(?:\.\d[\d_]*)?(?:[eE][+-]?\d[\d_]*)?)[lLfFdD]?/;
-    const operatorRe = /^(?:==|!=|<=|>=|\+\+|--|&&|\|\||<<=|>>=|>>>|<<|>>|::|->|\+=|-=|\*=|/=|%=|&=|\|=|\^=|[+\-*/%&|^!~<>=?:])/;
+    const operatorRe = /^(?:==|!=|<=|>=|\+\+|--|&&|\|\||<<=|>>=|>>>|<<|>>|::|->|\+=|-=|\*=|\/=|%=|&=|\|=|\^=|[+\-*/%&|^!~<>=?:])/;
     const punctRe = /^[(){}\[\],.;]/;
     let html = '';
     let i = 0;

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { parseMarkdown } = require('./app');
+const { parseMarkdown, sanitize } = require('./app');
 
 const md = `- Fruits
   - Apple
@@ -188,4 +188,16 @@ assert.strictEqual(htmlEscapeOutput, htmlEscapeExpected);
 const innerContent = htmlEscapeOutput.replace(/^<p>|<\/p>$/g, '');
 assert.ok(!/<[^>]+>/.test(innerContent));
 console.log('HTML escaping test passed.');
+
+const quoteMd = 'He said "Hello" and it\'s ok';
+const quoteExpected = '<p>He said &quot;Hello&quot; and it&#39;s ok</p>';
+assert.strictEqual(parseMarkdown(quoteMd), quoteExpected);
+console.log('Quote escaping test passed.');
+
+global.sanitize = sanitize;
+const { tokenizeJava } = require('./codeBlockSyntax_java.js');
+const tokenized = tokenizeJava('String s = "hi"; char c = \'c\';');
+assert.ok(tokenized.includes('&quot;hi&quot;'));
+assert.ok(tokenized.includes('&#39;c&#39;'));
+console.log('Tokenizer sanitization test passed.');
 


### PR DESCRIPTION
## Summary
- Escape double and single quotes in `sanitize`
- Reuse `sanitize` in tokenizer wrappers to avoid unsafe HTML injection
- Add tests for quote escaping and tokenizer sanitization

## Testing
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a67e0694ac832595ddf1d18efb1901