### PR TITLE
feat: tokenize large code blocks asynchronously

### DIFF
--- a/asyncTokenization.test.js
+++ b/asyncTokenization.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const piece = 'int a; ';
+let longCode = '';
+for (let i = 0; i < 3000; i++) longCode += piece; // ~21k characters
+
+const block = {
+  textContent: longCode,
+  className: 'language-java',
+  innerHTML: '',
+  attributes: {'data-tokenized': '0'},
+  setAttribute(name, value) { this.attributes[name] = value; },
+  getAttribute(name) { return this.attributes[name]; }
+};
+
+global.document = {
+  querySelectorAll() { return [block]; },
+  body: {}
+};
+
+global.MutationObserver = function() {
+  return { observe() {} };
+};
+
+require('./codeBlockSyntax_java.js');
+
+setTimeout(() => {
+  assert(block.innerHTML.includes('<span class="tok tok-keyword">int</span>'));
+  console.log('Async long code block tokenization test passed.');
+}, 100);
+


### PR DESCRIPTION
## Summary
- Tokenize code blocks larger than 20k characters in 5k chunks
- Schedule chunk processing via `requestIdleCallback` (fallback to `setTimeout`) and update DOM after all chunks complete
- Add async tokenization test verifying long blocks tokenize during idle periods and update DOM once finished

## Testing
- `node codeBlockSyntax_java.test.js`
- `node parseMarkdown.test.js`
- `node asyncTokenization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a67e2661f48325833516049bd4ec61