### PR TITLE
Add line numbers and theme toggle

### DIFF
--- a/codeBlockSyntax_java.js
+++ b/codeBlockSyntax_java.js
@@ -130,6 +130,11 @@
     }
   }
 
+  function addLineNumbers(block){
+    const lines = block.innerHTML.split(/\n/);
+    block.innerHTML = lines.map((line)=>`<span class="line">${line}</span>`).join('');
+  }
+
   // Tokenize a long code block piece by piece. Each CHUNK_SIZE slice is
   // scheduled via schedule() so work runs during idle periods. The DOM updates
   // once after all slices finish to minimize layout thrashing.
@@ -147,6 +152,7 @@
         schedule(()=>run(index + 1));
       } else {
         block.innerHTML = html;
+        addLineNumbers(block);
       }
     }
     schedule(()=>run(0));
@@ -167,6 +173,7 @@
         processLargeBlock(block, tokenizer);
       } else {
         block.innerHTML = tokenizer(text);
+        addLineNumbers(block);
         block.setAttribute('data-tokenized','1');
       }
     });
@@ -180,7 +187,26 @@
     observer.observe(document.body, {childList:true, subtree:true});
   }
 
+  function toggleTheme(theme){
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    const current = root.getAttribute('data-theme');
+    if (theme){
+      if (current === theme){
+        root.removeAttribute('data-theme');
+      } else {
+        root.setAttribute('data-theme', theme);
+      }
+    } else {
+      root.removeAttribute('data-theme');
+    }
+  }
+
+  if (typeof window !== 'undefined'){
+    window.toggleTheme = toggleTheme;
+  }
+
   if (typeof module !== 'undefined'){
-    module.exports = { registerLanguage, tokenizeJava };
+    module.exports = { registerLanguage, tokenizeJava, toggleTheme };
   }
 })();

--- a/syntax_highlight.css
+++ b/syntax_highlight.css
@@ -7,11 +7,37 @@
   --num: #b5cea8;
   --com: #6a9955;
   --func: #dcdcaa;
+  --line-num: #858585;
 }
 
 pre, code {
   background: var(--code-bg);
   color: var(--code-txt);
+}
+
+pre {
+  counter-reset: line;
+  padding-left: 2.5em;
+  position: relative;
+}
+
+pre code {
+  display: block;
+}
+
+pre code > .line {
+  counter-increment: line;
+  display: block;
+  position: relative;
+}
+
+pre code > .line::before {
+  content: counter(line);
+  position: absolute;
+  left: -2.5em;
+  width: 2em;
+  text-align: right;
+  color: var(--line-num);
 }
 
 .tok-keyword {
@@ -47,6 +73,7 @@ pre, code {
   --num: #098658;
   --com: #008000;
   --func: #795e26;
+  --line-num: #999;
 }
 
 [data-theme="high-contrast"] {
@@ -58,4 +85,5 @@ pre, code {
   --num: #ffff00;
   --com: #ffffff;
   --func: #00ff00;
+  --line-num: #fff;
 }


### PR DESCRIPTION
## Summary
- style: display code line numbers using CSS counters
- feat: expose `toggleTheme` helper to flip the `data-theme` attribute

## Testing
- `node codeBlockSyntax_java.test.js`
- `node parseMarkdown.test.js`
- `node asyncTokenization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a68090d6608325b37dac7239632867