### PR TITLE
Use inherited background for code blocks

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,7 +37,7 @@ code:not(pre code) {
 }
 
 pre code {
-  background: #f4f4f4;
+  background: inherit;
   padding: 0;
   border-radius: 0;
   display: block;


### PR DESCRIPTION
## Summary
- Ensure `pre code` elements inherit the background color of their parent `<pre>`
- Retain existing layout and spacing for code blocks

## Testing
- `node parseMarkdown.test.js`
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`
- Manual: Verified consistent code block backgrounds across default, light, and high-contrast themes via headless browser


------
https://chatgpt.com/codex/tasks/task_e_68a6841748248325a3f82fa2378aea75