### PR TITLE
Add editing/preview tabs to markdown editor

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,9 @@
-let editor, preview;
+let editor, preview, tabButtons, panes;
 if (typeof document !== 'undefined') {
   editor = document.getElementById('editor');
   preview = document.getElementById('preview');
+  tabButtons = document.querySelectorAll('.tabs button');
+  panes = document.querySelectorAll('.pane');
 }
 
 function sanitize(str) {
@@ -275,6 +277,24 @@ if (typeof document !== 'undefined') {
       }
     });
   }
+
+  function activatePane(targetId) {
+    panes.forEach((pane) => {
+      pane.classList.toggle('active', pane.id === targetId);
+    });
+    tabButtons.forEach((btn) => {
+      btn.classList.toggle('active', btn.dataset.target === targetId);
+    });
+    if (targetId === 'preview-pane') {
+      render();
+    }
+  }
+
+  tabButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      activatePane(btn.dataset.target);
+    });
+  });
 
   editor.addEventListener('input', render);
 

--- a/index.html
+++ b/index.html
@@ -8,8 +8,16 @@
   </head>
   <body>
     <div class="container">
-      <textarea id="editor" placeholder="ここにMarkdownを入力"></textarea>
-      <div id="preview"></div>
+      <div class="tabs">
+        <button class="active" data-target="editor-pane">編集</button>
+        <button data-target="preview-pane">プレビュー</button>
+      </div>
+      <div id="editor-pane" class="pane active">
+        <textarea id="editor" placeholder="ここにMarkdownを入力"></textarea>
+      </div>
+      <div id="preview-pane" class="pane">
+        <div id="preview"></div>
+      </div>
     </div>
     <script src="app.js"></script>
     <script src="codeBlockSyntax_java.js"></script>

--- a/style.css
+++ b/style.css
@@ -5,20 +5,49 @@ body {
 
 .container {
   display: flex;
+  flex-direction: column;
   height: 100vh;
 }
 
+.tabs {
+  display: flex;
+}
+
+.tabs button {
+  flex: 1;
+  padding: 0.5em;
+  cursor: pointer;
+  background: #eee;
+  border: none;
+  border-bottom: 1px solid #ccc;
+}
+
+.tabs button.active {
+  background: #fff;
+  border-bottom: none;
+}
+
+.pane {
+  flex: 1;
+  display: none;
+}
+
+.pane.active {
+  display: block;
+}
+
 #editor {
-  width: 50%;
+  width: 100%;
+  height: 100%;
   padding: 1em;
   border: none;
-  border-right: 1px solid #ccc;
   resize: none;
   font-family: monospace;
 }
 
 #preview {
-  width: 50%;
+  width: 100%;
+  height: 100%;
   padding: 1em;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
- Add tabbed interface with Edit and Preview panes.
- Style container and panes for tab layout.
- Enable tab switching in JavaScript, rendering preview on switch.

## Testing
- `node parseMarkdown.test.js`
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a698543b148325a55e805371d0238e