### PR TITLE
Make tabs sticky and add header shadow

### DIFF
--- a/markdown_editor.css
+++ b/markdown_editor.css
@@ -11,6 +11,11 @@ body {
 
 .tabs {
   display: flex;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: #fff;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
 .tabs button {


### PR DESCRIPTION
## Summary
- Keep tab headers fixed using `position: sticky` with top offset and z-index
- Add white background and subtle shadow to distinguish tabs from content

## Testing
- `node parseMarkdown.test.js`
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6a5a54b8483259895a07e96e90895