### PR TITLE
Add theme theme toggle and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
         <button class="active" data-target="editor-pane">編集</button>
         <button data-target="preview-pane">プレビュー</button>
       </div>
+      <button id="theme-toggle" onclick="toggleTheme('light')">Light/Dark</button>
       <div id="editor-pane" class="pane active">
         <textarea id="editor" placeholder="ここにMarkdownを入力"></textarea>
       </div>

--- a/themeToggle.test.js
+++ b/themeToggle.test.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+const { parseMarkdown } = require('./markdown_editor');
+
+// Minimal DOM stub for codeBlockSyntax_java.js
+const root = {
+  attrs: {},
+  setAttribute(name, value) { this.attrs[name] = value; },
+  getAttribute(name) { return this.attrs[name]; },
+  removeAttribute(name) { delete this.attrs[name]; }
+};
+
+global.document = {
+  documentElement: root,
+  querySelectorAll() { return []; },
+  body: {}
+};
+
+global.MutationObserver = function() { return { observe() {} }; };
+
+const { toggleTheme } = require('./codeBlockSyntax_java.js');
+
+// Markdown containing inline code and a code block
+const md = 'Inline `code` and:\n\n```java\nint x = 1;\n```';
+const html = parseMarkdown(md);
+
+// Ensure both inline and block code are rendered
+assert(html.includes('<code>code</code>'));
+assert(html.includes('<pre><button class="copy-btn">Copy</button><code class="language-java" data-tokenized="0">int x = 1;\n</code></pre>'));
+
+// Toggle on
+ toggleTheme('light');
+assert.strictEqual(document.documentElement.getAttribute('data-theme'), 'light');
+
+// Toggle off
+ toggleTheme('light');
+assert.strictEqual(document.documentElement.getAttribute('data-theme'), undefined);
+
+console.log('Theme toggle test passed.');


### PR DESCRIPTION
## Summary
- Add a Light/Dark theme toggle button in the editor UI.
- Provide tests verifying the theme toggle sets and clears the `data-theme` attribute.

## Testing
- `node parseMarkdown.test.js`
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`
- `node themeToggle.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7cb3724c48325b712d623f3642887