### PR TITLE
Sanitize code fence language identifiers

### DIFF
--- a/markdown_editor.js
+++ b/markdown_editor.js
@@ -128,7 +128,7 @@ function parseMarkdown(markdown) {
         inCode = false;
         codeDelimiter = null;
       } else if (!inCode) {
-        const lang = trimmedLine.slice(3).trim();
+        const lang = trimmedLine.slice(3).trim().replace(/[^A-Za-z0-9_-]/g, '');
         html += `<pre><button class="copy-btn">Copy</button><code class="language-${lang}" data-tokenized="0">`;
         inCode = true;
         codeDelimiter = delimiter;

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -62,6 +62,11 @@ const langCodeBlockExpected = '<pre><button class="copy-btn">Copy</button><code 
 assert.strictEqual(parseMarkdown(langCodeBlockMd), langCodeBlockExpected);
 console.log('Language code fence parsing test passed.');
 
+const maliciousLangCodeBlockMd = '```"<img src=x onerror=alert(1)>\ncode\n```';
+const maliciousLangCodeBlockExpected = '<pre><button class="copy-btn">Copy</button><code class="language-imgsrcxonerroralert1" data-tokenized="0">code\n</code></pre>';
+assert.strictEqual(parseMarkdown(maliciousLangCodeBlockMd), maliciousLangCodeBlockExpected);
+console.log('Malicious language code fence sanitization test passed.');
+
 const inlineCodeMd = 'This has `code` inline';
 const inlineCodeExpected = '<p>This has <code>code</code> inline</p>';
 assert.strictEqual(parseMarkdown(inlineCodeMd), inlineCodeExpected);


### PR DESCRIPTION
## Summary
- Strip non-alphanumeric characters from code fence language identifiers to prevent HTML injection
- Add unit test covering malicious language strings in fenced code blocks

## Testing
- `node parseMarkdown.test.js`
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7d12c4af083258a79639a2b66eec5