### PR TITLE
Refactor markdown editor to support multiple instances

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,5 +21,13 @@
     </div>
     <script src="markdown_editor.js"></script>
     <script src="codeBlockSyntax_java.js"></script>
+    <script>
+      new MarkdownEditor({
+        textarea: document.getElementById('editor'),
+        preview: document.getElementById('preview'),
+        tabButtons: document.querySelectorAll('.tabs button'),
+        panes: document.querySelectorAll('.pane'),
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor `markdown_editor.js` into `MarkdownEditor` class that accepts DOM elements and keeps state per instance
- update `index.html` to initialize the editor via new class-based API

## Testing
- `node parseMarkdown.test.js && node codeBlockSyntax_java.test.js && node asyncTokenization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7da6c6f6483258e28b426f5ae971e