### PR TITLE
refactor: extract table list blockquote parsing

### DIFF
--- a/markdown_editor.js
+++ b/markdown_editor.js
@@ -7,6 +7,109 @@ function sanitize(str) {
     .replace(/'/g, '&#39;');
 }
 
+function parseTables(lines, index) {
+  const line = lines[index];
+  const nextLine = lines[index + 1];
+  if (!nextLine || !line.includes('|')) return null;
+
+  const splitTableRow = (row) => {
+    let cells = row.trim();
+    if (cells.startsWith('|')) cells = cells.slice(1);
+    if (cells.endsWith('|')) cells = cells.slice(0, -1);
+    return cells.split('|').map((c) => c.trim());
+  };
+
+  const parseAlign = (line) => {
+    const cells = splitTableRow(line);
+    const aligns = [];
+    for (const cell of cells) {
+      const trimmed = cell.trim();
+      if (!/^:?-+:?$/.test(trimmed)) return null;
+      let align = null;
+      const left = trimmed.startsWith(':');
+      const right = trimmed.endsWith(':');
+      if (left && right) align = 'center';
+      else if (left) align = 'left';
+      else if (right) align = 'right';
+      aligns.push(align);
+    }
+    return aligns;
+  };
+
+  const aligns = parseAlign(nextLine);
+  if (!aligns) return null;
+  const headers = splitTableRow(line);
+  if (headers.length !== aligns.length) return null;
+
+  let i = index + 1;
+  let tableHtml = '<table><thead><tr>';
+  headers.forEach((cell, idx) => {
+    const align = aligns[idx];
+    const style = align ? ` style="text-align:${align}"` : '';
+    tableHtml += `<th${style}>${sanitize(cell)}</th>`;
+  });
+  tableHtml += '</tr></thead><tbody>';
+
+  while (i + 1 < lines.length && lines[i + 1].includes('|')) {
+    const row = splitTableRow(lines[i + 1]);
+    i++;
+    tableHtml += '<tr>';
+    row.forEach((cell, idx) => {
+      const align = aligns[idx];
+      const style = align ? ` style="text-align:${align}"` : '';
+      tableHtml += `<td${style}>${sanitize(cell)}</td>`;
+    });
+    tableHtml += '</tr>';
+  }
+  tableHtml += '</tbody></table>';
+  return { html: tableHtml, nextIndex: i };
+}
+
+function parseLists(line, listStack) {
+  const indentSpaces = line.match(/^ */)[0].length;
+  const trimmed = line.trimStart();
+  const ulMatch = /^[-*+] /.test(trimmed);
+  const olMatch = /^[0-9]+\. /.test(trimmed);
+  if (!ulMatch && !olMatch) return null;
+
+  const type = ulMatch ? 'ul' : 'ol';
+  const content = ulMatch
+    ? trimmed.replace(/^[-*+] /, '')
+    : trimmed.replace(/^[0-9]+\. /, '');
+  const depth = Math.floor(indentSpaces / 2) + 1;
+
+  const newStack = listStack.slice();
+  let html = '';
+
+  while (depth < newStack.length) {
+    html += `</li></${newStack.pop()}>`;
+  }
+  if (depth === newStack.length && newStack.length > 0) {
+    html += '</li>';
+  }
+  while (depth > newStack.length) {
+    html += `<${type}>`;
+    newStack.push(type);
+  }
+  if (newStack.length === 0 || newStack[newStack.length - 1] !== type) {
+    if (newStack.length > 0) {
+      html += `</${newStack.pop()}>`;
+    }
+    html += `<${type}>`;
+    newStack.push(type);
+  }
+  html += `<li>${sanitize(content)}`;
+  return { html, listStack: newStack };
+}
+
+function parseBlockquotes(line) {
+  const bqMatch = line.match(/^(>+)\s*/);
+  if (!bqMatch) return null;
+  const depth = bqMatch[1].length;
+  const content = sanitize(line.slice(bqMatch[0].length));
+  return { html: '<blockquote>'.repeat(depth) + content + '</blockquote>'.repeat(depth) };
+}
+
 function parseMarkdown(markdown) {
   const rawLines = markdown.split(/\r?\n/);
   const refLinks = {};
@@ -36,67 +139,21 @@ function parseMarkdown(markdown) {
     }
   };
 
-  function splitTableRow(row) {
-    let cells = row.trim();
-    if (cells.startsWith('|')) cells = cells.slice(1);
-    if (cells.endsWith('|')) cells = cells.slice(0, -1);
-    return cells.split('|').map((c) => c.trim());
-  }
-
-  function parseAlign(line) {
-    const cells = splitTableRow(line);
-    const aligns = [];
-    for (const cell of cells) {
-      const trimmed = cell.trim();
-      if (!/^:?-+:?$/.test(trimmed)) return null;
-      let align = null;
-      const left = trimmed.startsWith(':');
-      const right = trimmed.endsWith(':');
-      if (left && right) align = 'center';
-      else if (left) align = 'left';
-      else if (right) align = 'right';
-      aligns.push(align);
-    }
-    return aligns;
-  }
-
   for (let i = 0; i < lines.length; i++) {
     let line = lines[i];
     const trimmedLine = line.trim();
 
-    const nextLine = lines[i + 1];
-    if (nextLine && line.includes('|')) {
-      const aligns = parseAlign(nextLine);
-      if (aligns && splitTableRow(line).length === aligns.length) {
-        flushParagraph();
-        while (listStack.length > 0) {
-          html += `</li></${listStack.pop()}>`;
-        }
-        const headers = splitTableRow(line);
-        let tableHtml = '<table><thead><tr>';
-        headers.forEach((cell, idx) => {
-          const align = aligns[idx];
-          const style = align ? ` style="text-align:${align}"` : '';
-          tableHtml += `<th${style}>${sanitize(cell)}</th>`;
-        });
-        tableHtml += '</tr></thead><tbody>';
-        i++; // skip alignment row
-        while (i + 1 < lines.length && lines[i + 1].includes('|')) {
-          const row = splitTableRow(lines[i + 1]);
-          i++;
-          tableHtml += '<tr>';
-          row.forEach((cell, idx) => {
-            const align = aligns[idx];
-            const style = align ? ` style="text-align:${align}"` : '';
-            tableHtml += `<td${style}>${sanitize(cell)}</td>`;
-          });
-          tableHtml += '</tr>';
-        }
-        tableHtml += '</tbody></table>';
-        html += tableHtml;
-        continue;
+    const tableRes = parseTables(lines, i);
+    if (tableRes) {
+      flushParagraph();
+      while (listStack.length > 0) {
+        html += `</li></${listStack.pop()}>`;
       }
+      html += tableRes.html;
+      i = tableRes.nextIndex;
+      continue;
     }
+
     if (inCode && codeDelimiter === 'indent') {
       if (/^( {4}|\t)/.test(line)) {
         html += sanitize(line.replace(/^( {4}|\t)/, '')) + '\n';
@@ -135,37 +192,12 @@ function parseMarkdown(markdown) {
       continue;
     }
 
-    const indentSpaces = line.match(/^ */)[0].length;
-    const trimmed = line.trimStart();
-    const ulMatch = /^[-*+] /.test(trimmed);
-    const olMatch = /^[0-9]+\. /.test(trimmed);
-
-    if (ulMatch || olMatch) {
+    const listRes = parseLists(line, listStack);
+    if (listRes) {
       flushParagraph();
-      const type = ulMatch ? 'ul' : 'ol';
-      const content = ulMatch
-        ? trimmed.replace(/^[-*+] /, '')
-        : trimmed.replace(/^[0-9]+\. /, '');
-      const depth = Math.floor(indentSpaces / 2) + 1;
-
-      while (depth < listStack.length) {
-        html += `</li></${listStack.pop()}>`;
-      }
-      if (depth === listStack.length && listStack.length > 0) {
-        html += '</li>';
-      }
-      while (depth > listStack.length) {
-        html += `<${type}>`;
-        listStack.push(type);
-      }
-      if (listStack.length === 0 || listStack[listStack.length - 1] !== type) {
-        if (listStack.length > 0) {
-          html += `</${listStack.pop()}>`;
-        }
-        html += `<${type}>`;
-        listStack.push(type);
-      }
-      html += `<li>${sanitize(content)}`;
+      html += listRes.html;
+      listStack.length = 0;
+      Array.prototype.push.apply(listStack, listRes.listStack);
       continue;
     }
 
@@ -192,12 +224,10 @@ function parseMarkdown(markdown) {
       continue;
     }
 
-    const bqMatch = line.match(/^(>+)\s*/);
-    if (bqMatch) {
+    const bqRes = parseBlockquotes(line);
+    if (bqRes) {
       flushParagraph();
-      const depth = bqMatch[1].length;
-      const content = sanitize(line.slice(bqMatch[0].length));
-      html += '<blockquote>'.repeat(depth) + content + '</blockquote>'.repeat(depth);
+      html += bqRes.html;
       continue;
     }
 
@@ -344,6 +374,9 @@ if (typeof window !== 'undefined') {
   if (typeof module !== 'undefined') {
     module.exports = {
       parseMarkdown,
+      parseTables,
+      parseLists,
+      parseBlockquotes,
       sanitize,
       MarkdownEditor,
       renderMarkdownPreview,

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -1,5 +1,11 @@
 const assert = require('assert');
-const { parseMarkdown, sanitize } = require('./markdown_editor');
+const {
+  parseMarkdown,
+  sanitize,
+  parseTables,
+  parseLists,
+  parseBlockquotes,
+} = require('./markdown_editor');
 
 const md = `- Fruits
   - Apple
@@ -198,6 +204,25 @@ const quoteMd = 'He said "Hello" and it\'s ok';
 const quoteExpected = '<p>He said &quot;Hello&quot; and it&#39;s ok</p>';
 assert.strictEqual(parseMarkdown(quoteMd), quoteExpected);
 console.log('Quote escaping test passed.');
+
+// Pure function tests
+const listRes = parseLists('- Item', []);
+assert.deepStrictEqual(listRes, { html: '<ul><li>Item', listStack: ['ul'] });
+console.log('parseLists basic test passed.');
+
+const tableLines = ['| A |', '| - |', '| B |'];
+const tableRes = parseTables(tableLines, 0);
+const tableExpectedPure =
+  '<table><thead><tr><th>A</th></tr></thead><tbody><tr><td>B</td></tr></tbody></table>';
+assert.deepStrictEqual(tableRes, { html: tableExpectedPure, nextIndex: 2 });
+console.log('parseTables basic test passed.');
+
+const bqRes = parseBlockquotes('>> Quote');
+assert.strictEqual(
+  bqRes.html,
+  '<blockquote><blockquote>Quote</blockquote></blockquote>'
+);
+console.log('parseBlockquotes basic test passed.');
 
 global.sanitize = sanitize;
 const { tokenizeJava } = require('./codeBlockSyntax_java.js');


### PR DESCRIPTION
## Summary
- extract `parseTables`, `parseLists`, `parseBlockquotes` pure helpers
- delegate from `parseMarkdown` to new helpers
- add unit tests for the new pure functions

## Testing
- `node parseMarkdown.test.js`
- `node asyncTokenization.test.js`
- `node codeBlockSyntax_java.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8199f8b1c832589989f9a39d53c94