### PR TITLE
refactor: extract sanitize utility

### DIFF
--- a/codeBlockSyntax_java.js
+++ b/codeBlockSyntax_java.js
@@ -1,20 +1,15 @@
+let sanitize;
+if (typeof require !== 'undefined') {
+  sanitize = require('./sanitize').sanitize;
+} else if (typeof window !== 'undefined') {
+  sanitize = window.sanitize;
+}
+
 (function(){
   const languages = {};
 
-  function escapeHtml(str){
-    if (typeof sanitize === 'function'){
-      return sanitize(str);
-    }
-    return str
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
   function wrap(type, text){
-    return `<span class="tok tok-${type}">${escapeHtml(text)}</span>`;
+    return `<span class="tok tok-${type}">${sanitize(text)}</span>`;
   }
 
   function registerLanguage(name, tokenizer){
@@ -108,7 +103,7 @@
         i += punct[0].length;
         continue;
       }
-      html += escapeHtml(rest[0]);
+      html += sanitize(rest[0]);
       i++;
     }
     return html;

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         <div id="preview"></div>
       </div>
     </div>
+    <script src="sanitize.js"></script>
     <script src="markdown_editor.js"></script>
     <script src="codeBlockSyntax_java.js"></script>
     <script>

--- a/markdown_editor.js
+++ b/markdown_editor.js
@@ -1,10 +1,8 @@
-function sanitize(str) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+let sanitize;
+if (typeof require !== 'undefined') {
+  sanitize = require('./sanitize').sanitize;
+} else if (typeof window !== 'undefined') {
+  sanitize = window.sanitize;
 }
 
 function parseTables(lines, index) {

--- a/sanitize.js
+++ b/sanitize.js
@@ -1,0 +1,16 @@
+function sanitize(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+if (typeof window !== 'undefined') {
+  window.sanitize = sanitize;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { sanitize };
+}


### PR DESCRIPTION
## Summary
- move HTML escaping logic to new sanitize.js module
- use sanitize in markdown_editor.js and codeBlockSyntax_java.js, dropping duplicate escapeHtml
- include sanitize.js in index.html

## Testing
- `node codeBlockSyntax_java.test.js`
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a81b301c2083258c5ba9968eed3fe4