### PR TITLE
refactor: migrate Java syntax highlighter to ES modules

### DIFF
--- a/asyncTokenization.test.js
+++ b/asyncTokenization.test.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+import assert from 'node:assert';
 const piece = 'int a; ';
 let longCode = '';
 for (let i = 0; i < 3000; i++) longCode += piece; // ~21k characters
@@ -21,7 +21,7 @@ global.MutationObserver = function() {
   return { observe() {} };
 };
 
-require('./codeBlockSyntax_java.js');
+await import('./codeBlockSyntax_java.js');
 
 setTimeout(() => {
   assert(block.innerHTML.includes('<span class="tok tok-keyword">int</span>'));

--- a/codeBlockSyntax_java.js
+++ b/codeBlockSyntax_java.js
@@ -1,207 +1,187 @@
-let sanitize;
-if (typeof require !== 'undefined') {
-  sanitize = require('./sanitize').sanitize;
-} else if (typeof window !== 'undefined') {
-  sanitize = window.sanitize;
+import { sanitize } from './sanitize.js';
+
+const languages = {};
+
+function wrap(type, text) {
+  return `<span class="tok tok-${type}">${sanitize(text)}</span>`;
 }
 
-(function(){
-  const languages = {};
+export function registerLanguage(name, tokenizer) {
+  languages[name] = tokenizer;
+}
 
-  function wrap(type, text){
-    return `<span class="tok tok-${type}">${sanitize(text)}</span>`;
-  }
-
-  function registerLanguage(name, tokenizer){
-    languages[name] = tokenizer;
-  }
-
-  function tokenizeJava(code){
-    const keywordRe = /^(?:abstract|assert|boolean|break|byte|case|catch|char|class|const|continue|default|do|double|else|enum|extends|final|finally|float|for|if|goto|implements|import|instanceof|int|interface|long|native|new|package|private|protected|public|return|short|static|strictfp|super|switch|synchronized|this|throw|throws|transient|try|void|volatile|while|record)\b/;
-    const numberRe = /^(?:0[xX][0-9a-fA-F_]+|0[bB][01_]+|\d[\d_]*(?:\.\d[\d_]*)?(?:[eE][+-]?\d[\d_]*)?)[lLfFdD]?/;
-    const operatorRe = /^(?:==|!=|<=|>=|\+\+|--|&&|\|\||<<=|>>=|>>>|<<|>>|::|->|\+=|-=|\*=|\/=|%=|&=|\|=|\^=|[+\-*/%&|^!~<>=?:])/;
-    const punctRe = /^[(){}\[\],.;]/;
-    let html = '';
-    let i = 0;
-    let expectClassName = false;
-    while (i < code.length){
-      const rest = code.slice(i);
-      if (rest.startsWith('//')){
-        const end = rest.indexOf('\n');
-        const token = end === -1 ? rest : rest.slice(0,end);
-        html += wrap('comment', token);
-        i += token.length;
-        continue;
-      }
-      if (rest.startsWith('/*')){
-        const end = rest.indexOf('*/',2);
-        const token = end === -1 ? rest : rest.slice(0,end+2);
-        html += wrap('comment', token);
-        i += token.length;
-        continue;
-      }
-      if (rest[0] === '"'){
-        const m = rest.match(/^"(?:\\.|[^"\\])*"?/);
-        const token = m ? m[0] : rest[0];
-        html += wrap('string', token);
-        i += token.length;
-        continue;
-      }
-      if (rest[0] === '\''){
-        const m = rest.match(/^'(?:\\.|[^'\\])'?/);
-        const token = m ? m[0] : rest[0];
-        html += wrap('string', token);
-        i += token.length;
-        continue;
-      }
-      const num = rest.match(numberRe);
-      if (num){
-        html += wrap('number', num[0]);
-        i += num[0].length;
-        continue;
-      }
-      const ann = rest.match(/^@[A-Za-z_]\w*/);
-      if (ann){
-        html += wrap('annotation', ann[0]);
-        i += ann[0].length;
-        continue;
-      }
-      const kw = rest.match(keywordRe);
-      if (kw){
-        const token = kw[0];
-        html += wrap('keyword', token);
-        i += token.length;
-        expectClassName = /^(?:class|interface|enum|record)$/.test(token);
-        continue;
-      }
-      const ident = rest.match(/^[A-Za-z_]\w*/);
-      if (ident){
-        const name = ident[0];
-        const after = rest.slice(name.length);
-        const ws = after.match(/^\s*/)[0];
-        const next = after.slice(ws.length, ws.length+1);
-        let type = 'field';
-        if (expectClassName){
-          type = 'class';
-          expectClassName = false;
-        } else if (next === '('){
-          type = 'method';
-        }
-        html += wrap(type, name);
-        i += name.length;
-        continue;
-      }
-      const op = rest.match(operatorRe);
-      if (op){
-        html += wrap('operator', op[0]);
-        i += op[0].length;
-        continue;
-      }
-      const punct = rest.match(punctRe);
-      if (punct){
-        html += wrap('punctuation', punct[0]);
-        i += punct[0].length;
-        continue;
-      }
-      html += sanitize(rest[0]);
-      i++;
+export function tokenizeJava(code) {
+  const keywordRe = /^(?:abstract|assert|boolean|break|byte|case|catch|char|class|const|continue|default|do|double|else|enum|extends|final|finally|float|for|if|goto|implements|import|instanceof|int|interface|long|native|new|package|private|protected|public|return|short|static|strictfp|super|switch|synchronized|this|throw|throws|transient|try|void|volatile|while|record)\b/;
+  const numberRe = /^(?:0[xX][0-9a-fA-F_]+|0[bB][01_]+|\d[\d_]*(?:\.\d[\d_]*)?(?:[eE][+-]?\d[\d_]*)?)[lLfFdD]?/;
+  const operatorRe = /^(?:==|!=|<=|>=|\+\+|--|&&|\|\||<<=|>>=|>>>|<<|>>|::|->|\+=|-=|\*=|\/=|%=|&=|\|=|\^=|[+\-*/%&|^!~<>=?:])/;
+  const punctRe = /^[(){}\[\],.;]/;
+  let html = '';
+  let i = 0;
+  let expectClassName = false;
+  while (i < code.length) {
+    const rest = code.slice(i);
+    if (rest.startsWith('//')) {
+      const end = rest.indexOf('\n');
+      const token = end === -1 ? rest : rest.slice(0, end);
+      html += wrap('comment', token);
+      i += token.length;
+      continue;
     }
-    return html;
+    if (rest.startsWith('/*')) {
+      const end = rest.indexOf('*/', 2);
+      const token = end === -1 ? rest : rest.slice(0, end + 2);
+      html += wrap('comment', token);
+      i += token.length;
+      continue;
+    }
+    if (rest[0] === '"') {
+      const m = rest.match(/^"(?:\\.|[^"\\])*"?/);
+      const token = m ? m[0] : rest[0];
+      html += wrap('string', token);
+      i += token.length;
+      continue;
+    }
+    if (rest[0] === '\'') {
+      const m = rest.match(/^'(?:\\.|[^'\\])'?/);
+      const token = m ? m[0] : rest[0];
+      html += wrap('string', token);
+      i += token.length;
+      continue;
+    }
+    const num = rest.match(numberRe);
+    if (num) {
+      html += wrap('number', num[0]);
+      i += num[0].length;
+      continue;
+    }
+    const ann = rest.match(/^@[A-Za-z_]\w*/);
+    if (ann) {
+      html += wrap('annotation', ann[0]);
+      i += ann[0].length;
+      continue;
+    }
+    const kw = rest.match(keywordRe);
+    if (kw) {
+      const token = kw[0];
+      html += wrap('keyword', token);
+      i += token.length;
+      expectClassName = /^(?:class|interface|enum|record)$/.test(token);
+      continue;
+    }
+    const ident = rest.match(/^[A-Za-z_]\w*/);
+    if (ident) {
+      const name = ident[0];
+      const after = rest.slice(name.length);
+      const ws = after.match(/^\s*/)[0];
+      const next = after.slice(ws.length, ws.length + 1);
+      let type = 'field';
+      if (expectClassName) {
+        type = 'class';
+        expectClassName = false;
+      } else if (next === '(') {
+        type = 'method';
+      }
+      html += wrap(type, name);
+      i += name.length;
+      continue;
+    }
+    const op = rest.match(operatorRe);
+    if (op) {
+      html += wrap('operator', op[0]);
+      i += op[0].length;
+      continue;
+    }
+    const punct = rest.match(punctRe);
+    if (punct) {
+      html += wrap('punctuation', punct[0]);
+      i += punct[0].length;
+      continue;
+    }
+    html += sanitize(rest[0]);
+    i++;
   }
+  return html;
+}
 
-  // When code blocks grow beyond 20k characters, tokenizing them in one go can
-  // freeze the UI. Large blocks are therefore processed in smaller pieces and
-  // scheduled during idle periods to keep rendering responsive.
-  const LONG_CODE_THRESHOLD = 20000; // Start chunking past ~20k chars
-  const CHUNK_SIZE = 5000; // Process in 5k character chunks
+const LONG_CODE_THRESHOLD = 20000; // Start chunking past ~20k chars
+const CHUNK_SIZE = 5000; // Process in 5k character chunks
 
-  // Schedule a callback when the browser is idle; fall back to setTimeout to
-  // support environments without requestIdleCallback (e.g. Node tests).
-  function schedule(fn){
-    if (typeof requestIdleCallback === 'function'){
-      requestIdleCallback(fn);
+function schedule(fn) {
+  if (typeof requestIdleCallback === 'function') {
+    requestIdleCallback(fn);
+  } else {
+    setTimeout(fn, 0);
+  }
+}
+
+function addLineNumbers(block) {
+  const lines = block.innerHTML.split(/\n/);
+  block.innerHTML = lines
+    .map((line) => `<span class="line">${line}</span>`)
+    .join('');
+}
+
+function processLargeBlock(block, tokenizer) {
+  const text = block.textContent;
+  const chunks = [];
+  for (let i = 0; i < text.length; i += CHUNK_SIZE) {
+    chunks.push(text.slice(i, i + CHUNK_SIZE));
+  }
+  let html = '';
+  block.setAttribute('data-tokenized', '1');
+  function run(index) {
+    html += tokenizer(chunks[index]);
+    if (index + 1 < chunks.length) {
+      schedule(() => run(index + 1));
     } else {
-      setTimeout(fn, 0);
+      block.innerHTML = html;
+      addLineNumbers(block);
     }
   }
+  schedule(() => run(0));
+}
 
-  function addLineNumbers(block){
-    const lines = block.innerHTML.split(/\n/);
-    block.innerHTML = lines.map((line)=>`<span class="line">${line}</span>`).join('');
-  }
-
-  // Tokenize a long code block piece by piece. Each CHUNK_SIZE slice is
-  // scheduled via schedule() so work runs during idle periods. The DOM updates
-  // once after all slices finish to minimize layout thrashing.
-  function processLargeBlock(block, tokenizer){
+function processBlocks() {
+  if (typeof document === 'undefined') return;
+  const blocks = document.querySelectorAll(
+    'code[class^="language-"][data-tokenized="0"]'
+  );
+  blocks.forEach((block) => {
+    const m = block.className.match(/language-([\w-]+)/);
+    if (!m) return;
+    const lang = m[1];
+    const tokenizer = languages[lang];
+    if (!tokenizer) return;
     const text = block.textContent;
-    const chunks = [];
-    for (let i = 0; i < text.length; i += CHUNK_SIZE){
-      chunks.push(text.slice(i, i + CHUNK_SIZE));
-    }
-    let html = '';
-    block.setAttribute('data-tokenized', '1'); // Avoid duplicate processing
-    function run(index){
-      html += tokenizer(chunks[index]);
-      if (index + 1 < chunks.length){
-        schedule(()=>run(index + 1));
-      } else {
-        block.innerHTML = html;
-        addLineNumbers(block);
-      }
-    }
-    schedule(()=>run(0));
-  }
-
-  function processBlocks(){
-    if (typeof document === 'undefined') return;
-    const blocks = document.querySelectorAll('code[class^="language-"][data-tokenized="0"]');
-    blocks.forEach((block)=>{
-      const m = block.className.match(/language-([\w-]+)/);
-      if (!m) return;
-      const lang = m[1];
-      const tokenizer = languages[lang];
-      if (!tokenizer) return;
-      const text = block.textContent;
-      if (text.length > LONG_CODE_THRESHOLD){
-        // Large blocks are tokenized asynchronously in chunks.
-        processLargeBlock(block, tokenizer);
-      } else {
-        block.innerHTML = tokenizer(text);
-        addLineNumbers(block);
-        block.setAttribute('data-tokenized','1');
-      }
-    });
-  }
-
-  registerLanguage('java', tokenizeJava);
-
-  if (typeof document !== 'undefined'){
-    processBlocks();
-    const observer = new MutationObserver(processBlocks);
-    observer.observe(document.body, {childList:true, subtree:true});
-  }
-
-  function toggleTheme(theme){
-    if (typeof document === 'undefined') return;
-    const root = document.documentElement;
-    const current = root.getAttribute('data-theme');
-    if (theme){
-      if (current === theme){
-        root.removeAttribute('data-theme');
-      } else {
-        root.setAttribute('data-theme', theme);
-      }
+    if (text.length > LONG_CODE_THRESHOLD) {
+      processLargeBlock(block, tokenizer);
     } else {
-      root.removeAttribute('data-theme');
+      block.innerHTML = tokenizer(text);
+      addLineNumbers(block);
+      block.setAttribute('data-tokenized', '1');
     }
-  }
+  });
+}
 
-  if (typeof window !== 'undefined'){
-    window.toggleTheme = toggleTheme;
-  }
+registerLanguage('java', tokenizeJava);
 
-  if (typeof module !== 'undefined'){
-    module.exports = { registerLanguage, tokenizeJava, toggleTheme };
+if (typeof document !== 'undefined') {
+  processBlocks();
+  const observer = new MutationObserver(processBlocks);
+  observer.observe(document.body, { childList: true, subtree: true });
+}
+
+export function toggleTheme(theme) {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  const current = root.getAttribute('data-theme');
+  if (theme) {
+    if (current === theme) {
+      root.removeAttribute('data-theme');
+    } else {
+      root.setAttribute('data-theme', theme);
+    }
+  } else {
+    root.removeAttribute('data-theme');
   }
-})();
+}

--- a/codeBlockSyntax_java.test.js
+++ b/codeBlockSyntax_java.test.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const { tokenizeJava } = require('./codeBlockSyntax_java');
+import assert from 'node:assert';
+import { tokenizeJava } from './codeBlockSyntax_java.js';
 
 // Basic class and method tokenization
 let output = tokenizeJava(

--- a/index.html
+++ b/index.html
@@ -19,16 +19,18 @@
         <div id="preview"></div>
       </div>
     </div>
-    <script src="sanitize.js"></script>
-    <script src="markdown_editor.js"></script>
-    <script src="codeBlockSyntax_java.js"></script>
-    <script>
+    <script type="module">
+      import { MarkdownEditor } from './markdown_editor.js';
+      import { toggleTheme } from './codeBlockSyntax_java.js';
+
       new MarkdownEditor({
         textarea: document.getElementById('editor'),
         preview: document.getElementById('preview'),
         tabButtons: document.querySelectorAll('.tabs button'),
         panes: document.querySelectorAll('.pane'),
       });
+
+      window.toggleTheme = toggleTheme;
     </script>
   </body>
 </html>

--- a/markdown_editor.js
+++ b/markdown_editor.js
@@ -1,9 +1,4 @@
-let sanitize;
-if (typeof require !== 'undefined') {
-  sanitize = require('./sanitize').sanitize;
-} else if (typeof window !== 'undefined') {
-  sanitize = window.sanitize;
-}
+import { sanitize } from './sanitize.js';
 
 function parseTables(lines, index) {
   const line = lines[index];
@@ -363,22 +358,14 @@ function initPreview(outputEl, sourceText = '') {
   renderMarkdownPreview(outputEl, sourceText);
 }
 
-if (typeof window !== 'undefined') {
-  window.MarkdownEditor = MarkdownEditor;
-  window.renderMarkdownPreview = renderMarkdownPreview;
-  window.initPreview = initPreview;
-}
-
-  if (typeof module !== 'undefined') {
-    module.exports = {
-      parseMarkdown,
-      parseTables,
-      parseLists,
-      parseBlockquotes,
-      sanitize,
-      MarkdownEditor,
-      renderMarkdownPreview,
-      initPreview,
-      processCodeBlocks,
-    };
-  }
+export {
+  parseMarkdown,
+  parseTables,
+  parseLists,
+  parseBlockquotes,
+  sanitize,
+  MarkdownEditor,
+  renderMarkdownPreview,
+  initPreview,
+  processCodeBlocks,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -1,11 +1,11 @@
-const assert = require('assert');
-const {
+import assert from 'node:assert';
+import {
   parseMarkdown,
   sanitize,
   parseTables,
   parseLists,
   parseBlockquotes,
-} = require('./markdown_editor');
+} from './markdown_editor.js';
 
 const md = `- Fruits
   - Apple
@@ -224,8 +224,7 @@ assert.strictEqual(
 );
 console.log('parseBlockquotes basic test passed.');
 
-global.sanitize = sanitize;
-const { tokenizeJava } = require('./codeBlockSyntax_java.js');
+import { tokenizeJava } from './codeBlockSyntax_java.js';
 const tokenized = tokenizeJava('String s = "hi"; char c = \'c\';');
 assert.ok(tokenized.includes('&quot;hi&quot;'));
 assert.ok(tokenized.includes('&#39;c&#39;'));

--- a/sanitize.js
+++ b/sanitize.js
@@ -1,16 +1,8 @@
-function sanitize(str) {
+export function sanitize(str) {
   return str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
-}
-
-if (typeof window !== 'undefined') {
-  window.sanitize = sanitize;
-}
-
-if (typeof module !== 'undefined') {
-  module.exports = { sanitize };
 }


### PR DESCRIPTION
## Summary
- convert sanitize helper and Java tokenizer to ES modules and export registerLanguage, tokenizeJava, toggleTheme
- update markdown editor and browser entrypoint to use ES module imports
- add package.json to set module type and update tests to use ES modules

## Testing
- `node codeBlockSyntax_java.test.js && node parseMarkdown.test.js && node asyncTokenization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a81c7616bc83258aa144f546b74297