### PR TITLE
feat: add destroy method to editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,18 @@ JavaScript で書かれたシンプルな Markdown エディタとプレビュ�
 
 <script src="markdown_editor.js"></script>
 <script>
-  new MarkdownEditor({
+  const editor = new MarkdownEditor({
     textarea: document.getElementById('editor'),
     preview: document.getElementById('preview'),
     tabButtons: document.querySelectorAll('.tabs button'),
     panes: document.querySelectorAll('.pane'),
   });
+  // 不要になったタイミングで
+  // editor.destroy();
 </script>
 ```
+
+生成されたインスタンスの `destroy()` を呼び出すと、イベントリスナが解除され参照がクリアされます。
 
 ### `renderMarkdownPreview`
 

--- a/markdownEditor.destroy.test.js
+++ b/markdownEditor.destroy.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import { MarkdownEditor } from './markdown_editor.js';
+
+const dom = new JSDOM(`<textarea id="editor"></textarea><div id="preview"></div>`);
+const { window } = dom;
+const { document } = window;
+
+global.window = window;
+global.document = document;
+
+const textarea = document.getElementById('editor');
+const preview = document.getElementById('preview');
+
+const editor = new MarkdownEditor({ textarea, preview });
+
+textarea.value = '# hello';
+textarea.dispatchEvent(new window.Event('input', { bubbles: true }));
+const initial = preview.innerHTML;
+
+editor.destroy();
+
+textarea.value = '# bye';
+textarea.dispatchEvent(new window.Event('input', { bubbles: true }));
+assert.strictEqual(preview.innerHTML, initial);
+
+textarea.value = 'test';
+textarea.dispatchEvent(
+  new window.KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true })
+);
+assert.strictEqual(textarea.value, 'test');
+
+assert.strictEqual(editor.editor, null);
+assert.strictEqual(editor.preview, null);
+
+console.log('MarkdownEditor destroy test passed.');

--- a/markdown_editor.js
+++ b/markdown_editor.js
@@ -303,10 +303,13 @@ class MarkdownEditor {
     this.render = this.render.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.activatePane = this.activatePane.bind(this);
+    this.tabButtonHandlers = [];
     this.tabButtons.forEach((btn) => {
-      btn.addEventListener('click', () => {
+      const handler = () => {
         this.activatePane(btn.dataset.target);
-      });
+      };
+      btn.addEventListener('click', handler);
+      this.tabButtonHandlers.push({ btn, handler });
     });
     if (this.editor) {
       this.editor.addEventListener('input', this.render);
@@ -344,6 +347,22 @@ class MarkdownEditor {
         value.substring(0, start) + '    ' + value.substring(end);
       this.editor.selectionStart = this.editor.selectionEnd = start + 4;
     }
+  }
+
+  destroy() {
+    if (this.editor) {
+      this.editor.removeEventListener('input', this.render);
+      this.editor.removeEventListener('keydown', this.handleKeyDown);
+    }
+    this.tabButtonHandlers.forEach(({ btn, handler }) => {
+      btn.removeEventListener('click', handler);
+    });
+    this.editor = null;
+    this.preview = null;
+    this.tabButtons = [];
+    this.panes = [];
+    this.previewPane = null;
+    this.tabButtonHandlers = [];
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,3 +1,6 @@
 {
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "jsdom": "^26.1.0"
+  }
 }


### PR DESCRIPTION
## Summary
- add destroy method to MarkdownEditor to clean up event listeners
- document destroy usage in README
- add unit test for destroy behavior

## Testing
- `node parseMarkdown.test.js`
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`
- `node markdownEditor.destroy.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a81dd051148325b4c36c7dfd09e352