### PR TITLE
docs: clarify default ids and custom initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,20 @@
 
 JavaScript で書かれたシンプルな Markdown エディタとプレビュー用ユーティリティです。
 
-このプロジェクトでは既存のhtml内の要素にid="md_editor"  id="md_preview"を加えることでそれぞれテキストをmd変換する機能とmdEditor機能を提供します。
-複数の異なる要素にそれそれぞれ異なるオブジェクトとしてmd_editorとmd_previewを提供することはできます。
+このプロジェクトでは既存の HTML 内の要素に `id="editor"` と `id="preview"` を加えることで、それぞれテキストを Markdown に変換する機能と Markdown エディタ機能を提供します。
+複数の異なる要素にそれぞれ異なるオブジェクトとして `editor` と `preview` を提供することもできます。
+
+任意の ID を使いたい場合は `new MarkdownEditor({ textarea: ..., preview: ... })` のように要素を明示的に渡してください。例えば:
+
+```html
+<textarea id="my-editor"></textarea>
+<div id="my-preview"></div>
+<script type="module">
+  import { MarkdownEditor } from './markdown_editor.js';
+
+  new MarkdownEditor({
+    textarea: document.getElementById('my-editor'),
+    preview: document.getElementById('my-preview'),
+  });
+</script>
+```


### PR DESCRIPTION
## Summary
- document default `id="editor"` and `id="preview"`
- show how to pass custom elements to `MarkdownEditor`

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a821063ee483259056adb0c4ef69a8