### PR TITLE
Use class-based selectors for default editor elements

### DIFF
--- a/markdownEditor.default.test.js
+++ b/markdownEditor.default.test.js
@@ -1,0 +1,29 @@
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import { MarkdownEditor } from './markdown_editor.js';
+
+const dom = new JSDOM(`<textarea class="editor"></textarea><div class="preview"></div>`);
+const { window } = dom;
+const { document } = window;
+
+global.window = window;
+global.document = document;
+
+const editorInstance = new MarkdownEditor();
+
+const textarea = document.querySelector('.editor');
+const preview = document.querySelector('.preview');
+
+textarea.value = '# hello';
+textarea.dispatchEvent(new window.Event('input', { bubbles: true }));
+assert.strictEqual(preview.innerHTML.trim(), '<h1>hello</h1>');
+
+const initial = preview.innerHTML;
+
+editorInstance.destroy();
+
+textarea.value = '# bye';
+textarea.dispatchEvent(new window.Event('input', { bubbles: true }));
+assert.strictEqual(preview.innerHTML, initial);
+
+console.log('MarkdownEditor default class selection test passed.');

--- a/markdown_editor.js
+++ b/markdown_editor.js
@@ -298,8 +298,8 @@ function processCodeBlocks(container) {
 class MarkdownEditor {
   constructor({ textarea, preview, tabButtons, panes } = {}) {
     if (typeof document === 'undefined') return;
-    this.editor = textarea || document.getElementById('editor');
-    this.preview = preview || document.getElementById('preview');
+    this.editor = textarea || document.querySelector('.editor');
+    this.preview = preview || document.querySelector('.preview');
     this.tabButtons = tabButtons
       ? Array.from(tabButtons)
       : Array.from(document.querySelectorAll('.tabs button'));


### PR DESCRIPTION
## Summary
- Default editor and preview elements now selected via `.editor` and `.preview` classes
- Add test ensuring default class-based selection renders and detaches correctly

## Testing
- `node asyncTokenization.test.js`
- `node codeBlockSyntax_java.test.js`
- `node markdownEditor.destroy.test.js`
- `node markdownEditor.default.test.js`
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68abf09fb7988325a5db98d233f9d3c5