### PR TITLE
Use class selectors for editor and preview elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ JavaScript で書かれたシンプルな Markdown エディタとプレビュ�
 ### 素の HTML での利用
 
 ```html
-<textarea id="editor"></textarea>
-<div id="preview"></div>
+<textarea class="editor"></textarea>
+<div class="preview"></div>
 <script type="module">
   import { MarkdownEditor } from './markdown_editor.js';
   import { toggleTheme } from './codeBlockSyntax_java.js';
 
   new MarkdownEditor({
-    textarea: document.getElementById('editor'),
-    preview: document.getElementById('preview'),
+    textarea: document.querySelector('.editor'),
+    preview: document.querySelector('.preview'),
   });
 
   // オプション: テーマ切り替え
@@ -40,13 +40,13 @@ JavaScript で書かれたシンプルな Markdown エディタとプレビュ�
     <script type="module" src="/js/codeBlockSyntax_java.js"></script>
   </head>
   <body>
-    <textarea id="editor"></textarea>
-    <div id="preview"></div>
+    <textarea class="editor"></textarea>
+    <div class="preview"></div>
     <script type="module">
       import { MarkdownEditor } from '/js/markdown_editor.js';
       new MarkdownEditor({
-        textarea: document.getElementById('editor'),
-        preview: document.getElementById('preview'),
+        textarea: document.querySelector('.editor'),
+        preview: document.querySelector('.preview'),
       });
     </script>
   </body>

--- a/index.html
+++ b/index.html
@@ -13,10 +13,10 @@
         <button data-target="preview-pane">プレビュー</button>
       </div>
       <div id="editor-pane" class="pane active">
-        <textarea id="editor" placeholder="ここにMarkdownを入力"></textarea>
+        <textarea class="editor" placeholder="ここにMarkdownを入力"></textarea>
       </div>
       <div id="preview-pane" class="pane">
-        <div id="preview"></div>
+        <div class="preview"></div>
       </div>
     </div>
     <script type="module">
@@ -24,8 +24,8 @@
       import { toggleTheme } from './codeBlockSyntax_java.js';
 
       new MarkdownEditor({
-        textarea: document.getElementById('editor'),
-        preview: document.getElementById('preview'),
+        textarea: document.querySelector('.editor'),
+        preview: document.querySelector('.preview'),
         tabButtons: document.querySelectorAll('.tabs button'),
         panes: document.querySelectorAll('.pane'),
       });

--- a/markdownEditor.destroy.test.js
+++ b/markdownEditor.destroy.test.js
@@ -2,15 +2,15 @@ import assert from 'node:assert';
 import { JSDOM } from 'jsdom';
 import { MarkdownEditor } from './markdown_editor.js';
 
-const dom = new JSDOM(`<textarea id="editor"></textarea><div id="preview"></div>`);
+const dom = new JSDOM(`<textarea class="editor"></textarea><div class="preview"></div>`);
 const { window } = dom;
 const { document } = window;
 
 global.window = window;
 global.document = document;
 
-const textarea = document.getElementById('editor');
-const preview = document.getElementById('preview');
+const textarea = document.querySelector('.editor');
+const preview = document.querySelector('.preview');
 
 const editor = new MarkdownEditor({ textarea, preview });
 

--- a/markdown_editor.css
+++ b/markdown_editor.css
@@ -46,7 +46,7 @@ body {
   display: block;
 }
 
-#editor {
+.editor {
   width: 100%;
   height: 100%;
   padding: 1em;
@@ -55,7 +55,7 @@ body {
   font-family: monospace;
 }
 
-#preview {
+.preview {
   width: 100%;
   height: 100%;
   padding: 1em;


### PR DESCRIPTION
## Summary
- replace editor/preview IDs with class names
- query editor and preview elements via `document.querySelector`
- update tests, styles, and docs for class-based selection

## Testing
- `node parseMarkdown.test.js`
- `node markdownEditor.default.test.js`
- `node markdownEditor.destroy.test.js`
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68abf35fb5988325b43e57e3881303b5