### PR TITLE
Use class selectors for editor and preview

### DIFF
--- a/markdown_editor.css
+++ b/markdown_editor.css
@@ -46,19 +46,20 @@ body {
   display: block;
 }
 
-.editor {
+.editor,
+.preview {
   width: 100%;
   height: 100%;
   padding: 1em;
+}
+
+.editor {
   border: none;
   resize: none;
   font-family: monospace;
 }
 
 .preview {
-  width: 100%;
-  height: 100%;
-  padding: 1em;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- Consolidate shared rules for editor and preview and rely on class selectors instead of IDs
- Ensure no leftover ID-specific styling remains

## Testing
- `node parseMarkdown.test.js`
- `node markdownEditor.default.test.js && node markdownEditor.destroy.test.js && node asyncTokenization.test.js && node codeBlockSyntax_java.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68abf489539c8325a03aed76d1c92ddf