### PR TITLE
feat: highlight additional java keywords

### DIFF
--- a/codeBlockSyntax_java.js
+++ b/codeBlockSyntax_java.js
@@ -18,7 +18,7 @@ export function registerLanguage(name, tokenizer) {
 }
 
 export function tokenizeJava(code) {
-  const keywordRe = /^(?:abstract|assert|boolean|break|byte|case|catch|char|class|const|continue|default|do|double|else|enum|extends|final|finally|float|for|if|goto|implements|import|instanceof|int|interface|long|native|new|package|private|protected|public|return|short|static|strictfp|super|switch|synchronized|this|throw|throws|transient|try|void|volatile|while|record)\b/;
+  const keywordRe = /^(?:abstract|assert|boolean|break|byte|case|catch|char|class|const|continue|default|do|double|else|enum|extends|final|finally|float|for|if|goto|implements|import|instanceof|int|interface|long|native|new|package|private|protected|public|return|short|static|strictfp|super|switch|synchronized|this|throw|throws|transient|try|void|volatile|while|record|var|yield|sealed|permits|non-sealed|module|open|requires|exports|opens|uses|provides|transitive)\b/;
   const numberRe = /^(?:0[xX][0-9a-fA-F_]+|0[bB][01_]+|\d[\d_]*(?:\.\d[\d_]*)?(?:[eE][+-]?\d[\d_]*)?)[lLfFdD]?/;
   const operatorRe = /^(?:==|!=|<=|>=|\+\+|--|&&|\|\||<<=|>>=|>>>|<<|>>|::|->|\+=|-=|\*=|\/=|%=|&=|\|=|\^=|[+\-*/%&|^!~<>=?:])/;
   const punctRe = /^[(){}\[\],.;]/;

--- a/codeBlockSyntax_java.test.js
+++ b/codeBlockSyntax_java.test.js
@@ -38,3 +38,22 @@ output = tokenizeJava('int x = 0xFF; double y = 3.14e10;');
 assert(output.includes('<span class="tok tok-number">0xFF</span>'));
 assert(output.includes('<span class="tok tok-number">3.14e10</span>'));
 console.log('Numeric literal tokenization test passed.');
+
+// Extended keyword set
+output = tokenizeJava(
+  'var x = 1; yield x; sealed interface S permits T {} non-sealed class N permits S {} open module M { requires transitive N; exports p; opens q; uses r; provides s with t; }'
+);
+assert(output.includes('<span class="tok tok-keyword">var</span>'));
+assert(output.includes('<span class="tok tok-keyword">yield</span>'));
+assert(output.includes('<span class="tok tok-keyword">sealed</span>'));
+assert(output.includes('<span class="tok tok-keyword">permits</span>'));
+assert(output.includes('<span class="tok tok-keyword">non-sealed</span>'));
+assert(output.includes('<span class="tok tok-keyword">module</span>'));
+assert(output.includes('<span class="tok tok-keyword">open</span>'));
+assert(output.includes('<span class="tok tok-keyword">requires</span>'));
+assert(output.includes('<span class="tok tok-keyword">exports</span>'));
+assert(output.includes('<span class="tok tok-keyword">opens</span>'));
+assert(output.includes('<span class="tok tok-keyword">uses</span>'));
+assert(output.includes('<span class="tok tok-keyword">provides</span>'));
+assert(output.includes('<span class="tok tok-keyword">transitive</span>'));
+console.log('Extended keyword tokenization test passed.');


### PR DESCRIPTION
## Summary
- extend Java tokenizer keyword list to cover modern keywords like `var`, `sealed`, `module` and others
- test new Java keywords highlighting

## Testing
- `node codeBlockSyntax_java.test.js`
- `node parseMarkdown.test.js`
- `node asyncTokenization.test.js`
- `node markdownEditor.default.test.js`
- `node markdownEditor.destroy.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68abf80c0e648325a64dcf290fe1dd0b