### PR TITLE
feat(java): support text blocks and literals

### DIFF
--- a/codeBlockSyntax_java.js
+++ b/codeBlockSyntax_java.js
@@ -19,6 +19,7 @@ export function registerLanguage(name, tokenizer) {
 
 export function tokenizeJava(code) {
   const keywordRe = /^(?:abstract|assert|boolean|break|byte|case|catch|char|class|const|continue|default|do|double|else|enum|extends|final|finally|float|for|if|goto|implements|import|instanceof|int|interface|long|native|new|package|private|protected|public|return|short|static|strictfp|super|switch|synchronized|this|throw|throws|transient|try|void|volatile|while|record|var|yield|sealed|permits|non-sealed|module|open|requires|exports|opens|uses|provides|transitive)\b/;
+  const literalRe = /^(?:true|false|null)\b/;
   const numberRe = /^(?:0[xX][0-9a-fA-F_]+|0[bB][01_]+|\d[\d_]*(?:\.\d[\d_]*)?(?:[eE][+-]?\d[\d_]*)?)[lLfFdD]?/;
   const operatorRe = /^(?:==|!=|<=|>=|\+\+|--|&&|\|\||<<=|>>=|>>>|<<|>>|::|->|\+=|-=|\*=|\/=|%=|&=|\|=|\^=|[+\-*/%&|^!~<>=?:])/;
   const punctRe = /^[(){}\[\],.;]/;
@@ -38,6 +39,13 @@ export function tokenizeJava(code) {
       const end = rest.indexOf('*/', 2);
       const token = end === -1 ? rest : rest.slice(0, end + 2);
       html += wrap('comment', token);
+      i += token.length;
+      continue;
+    }
+    if (rest.startsWith('"""')) {
+      const end = rest.indexOf('"""', 3);
+      const token = end === -1 ? rest : rest.slice(0, end + 3);
+      html += wrap('string', token);
       i += token.length;
       continue;
     }
@@ -73,6 +81,12 @@ export function tokenizeJava(code) {
       html += wrap('keyword', token);
       i += token.length;
       expectClassName = /^(?:class|interface|enum|record)$/.test(token);
+      continue;
+    }
+    const lit = rest.match(literalRe);
+    if (lit) {
+      html += wrap('literal', lit[0]);
+      i += lit[0].length;
       continue;
     }
     const ident = rest.match(/^[A-Za-z_]\w*/);

--- a/codeBlockSyntax_java.test.js
+++ b/codeBlockSyntax_java.test.js
@@ -39,6 +39,22 @@ assert(output.includes('<span class="tok tok-number">0xFF</span>'));
 assert(output.includes('<span class="tok tok-number">3.14e10</span>'));
 console.log('Numeric literal tokenization test passed.');
 
+// Text block string
+output = tokenizeJava('String s = """hello""";');
+assert(
+  output.includes(
+    '<span class="tok tok-string">&quot;&quot;&quot;hello&quot;&quot;&quot;</span>'
+  )
+);
+console.log('Text block string tokenization test passed.');
+
+// Boolean and null literals
+output = tokenizeJava('boolean a = true; boolean b = false; Object c = null;');
+assert(output.includes('<span class="tok tok-literal">true</span>'));
+assert(output.includes('<span class="tok tok-literal">false</span>'));
+assert(output.includes('<span class="tok tok-literal">null</span>'));
+console.log('Boolean and null literal tokenization test passed.');
+
 // Extended keyword set
 output = tokenizeJava(
   'var x = 1; yield x; sealed interface S permits T {} non-sealed class N permits S {} open module M { requires transitive N; exports p; opens q; uses r; provides s with t; }'


### PR DESCRIPTION
## Summary
- highlight Java text blocks delimited with triple quotes as strings
- recognize `true`, `false`, and `null` as literals
- add unit tests for text blocks and literal keywords

## Testing
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`
- `node markdownEditor.default.test.js`
- `node markdownEditor.destroy.test.js`
- `node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68abfa96da588325a9fedd8ae3afa5eb