### PR TITLE
Improve Java tokenizer class detection

### DIFF
--- a/codeBlockSyntax_java.js
+++ b/codeBlockSyntax_java.js
@@ -80,7 +80,9 @@ export function tokenizeJava(code) {
       const token = kw[0];
       html += wrap('keyword', token);
       i += token.length;
-      expectClassName = /^(?:class|interface|enum|record)$/.test(token);
+      expectClassName = /^(?:class|interface|enum|record|new|extends|implements|throws)$/.test(
+        token
+      );
       continue;
     }
     const lit = rest.match(literalRe);
@@ -96,7 +98,7 @@ export function tokenizeJava(code) {
       const ws = after.match(/^\s*/)[0];
       const next = after.slice(ws.length, ws.length + 1);
       let type = 'field';
-      if (expectClassName) {
+      if (expectClassName || /^[A-Z]/.test(name)) {
         type = 'class';
         expectClassName = false;
       } else if (next === '(') {

--- a/codeBlockSyntax_java.test.js
+++ b/codeBlockSyntax_java.test.js
@@ -13,6 +13,12 @@ assert(output.includes('<span class="tok tok-keyword">void</span>'));
 assert(output.includes('<span class="tok tok-method">main</span>'));
 console.log('Basic Java tokenization test passed.');
 
+// System.out.println retains class/field/method tokens
+assert(output.includes('<span class="tok tok-class">System</span>'));
+assert(output.includes('<span class="tok tok-field">out</span>'));
+assert(output.includes('<span class="tok tok-method">println</span>'));
+console.log('System.out.println tokenization test passed.');
+
 // Annotation handling
 output = tokenizeJava(
   'class Hello { @Override public String toString() { return "Hi"; } }'
@@ -73,3 +79,18 @@ assert(output.includes('<span class="tok tok-keyword">uses</span>'));
 assert(output.includes('<span class="tok tok-keyword">provides</span>'));
 assert(output.includes('<span class="tok tok-keyword">transitive</span>'));
 console.log('Extended keyword tokenization test passed.');
+
+// Class name expectations after new/extends/implements/throws
+output = tokenizeJava(
+  'class A extends B implements C { void m() throws D { new E(); } }'
+);
+assert(output.includes('<span class="tok tok-class">B</span>'));
+assert(output.includes('<span class="tok tok-class">C</span>'));
+assert(output.includes('<span class="tok tok-class">D</span>'));
+assert(output.includes('<span class="tok tok-class">E</span>'));
+console.log('Class name expectation test passed.');
+
+// Uppercase heuristic for class names
+output = tokenizeJava('List items;');
+assert(output.includes('<span class="tok tok-class">List</span>'));
+console.log('Uppercase heuristic test passed.');


### PR DESCRIPTION
## Summary
- Recognize class names after `new`, `extends`, `implements`, and `throws`
- Treat identifiers starting with uppercase as class names
- Add tests covering `System.out.println` and class-name heuristics

## Testing
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`
- `node parseMarkdown.test.js`
- `node markdownEditor.default.test.js`
- `node markdownEditor.destroy.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68abfbb2fc888325ade3d95fe4d341c9