### PR TITLE
feat: extend syntax highlighting token support

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,15 @@
         <div class="preview"></div>
       </div>
     </div>
+    <pre><code class="language-java" data-tokenized="0">
+@Annot
+class Sample {
+  int field;
+  void method() {
+    field++;
+  }
+}
+</code></pre>
     <script type="module">
       import { MarkdownEditor } from './markdown_editor.js';
       import { toggleTheme } from './codeBlockSyntax_java.js';

--- a/syntax_highlight.css
+++ b/syntax_highlight.css
@@ -5,6 +5,12 @@
   --num: #b5cea8;
   --com: #6a9955;
   --func: #dcdcaa;
+  --annot: #c8c8c8;
+  --class: #4ec9b0;
+  --method: #dcdcaa;
+  --field: #9cdcfe;
+  --op: #d4d4d4;
+  --punct: #d4d4d4;
   --line-num: #858585;
 }
 
@@ -61,6 +67,30 @@ pre code > .line::before {
   color: var(--func);
 }
 
+.tok-annotation {
+  color: var(--annot);
+}
+
+.tok-class {
+  color: var(--class);
+}
+
+.tok-method {
+  color: var(--method);
+}
+
+.tok-field {
+  color: var(--field);
+}
+
+.tok-operator {
+  color: var(--op);
+}
+
+.tok-punctuation {
+  color: var(--punct);
+}
+
 [data-theme="light"] {
   --code-txt: #333;
   --kw: #0000ff;
@@ -69,6 +99,12 @@ pre code > .line::before {
   --num: #098658;
   --com: #008000;
   --func: #795e26;
+  --annot: #267f99;
+  --class: #267f99;
+  --method: #795e26;
+  --field: #001080;
+  --op: #000;
+  --punct: #000;
   --line-num: #999;
 }
 
@@ -80,5 +116,11 @@ pre code > .line::before {
   --num: #ffff00;
   --com: #ffffff;
   --func: #00ff00;
+  --annot: #ff00ff;
+  --class: #a4ffff;
+  --method: #00ff00;
+  --field: #ffff00;
+  --op: #ffffff;
+  --punct: #ffffff;
   --line-num: #fff;
 }


### PR DESCRIPTION
## Summary
- add CSS variables and token classes for annotations, classes, methods, fields, operators, and punctuation
- include default, light, and high-contrast theme values
- add sample Java snippet to index.html to showcase new highlighting

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68ac02b8077483259893ae43b66fc9a2