### PR TITLE
Add tests for Java tokenizer features and async tokenization

### DIFF
--- a/asyncTokenization.test.js
+++ b/asyncTokenization.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
-const piece = 'int a; ';
+const piece = 'boolean a = true; Boolean b = false; Object c = null; String s = """hi"""; new foo(); class bar extends baz {} ';
 let longCode = '';
-for (let i = 0; i < 3000; i++) longCode += piece; // ~21k characters
+for (let i = 0; i < 400; i++) longCode += piece; // ~40k characters
 
 const block = {
   textContent: longCode,
@@ -14,7 +14,7 @@ const block = {
 
 global.document = {
   querySelectorAll() { return [block]; },
-  body: {}
+  body: {},
 };
 
 global.MutationObserver = function() {
@@ -24,7 +24,17 @@ global.MutationObserver = function() {
 await import('./codeBlockSyntax_java.js');
 
 setTimeout(() => {
-  assert(block.innerHTML.includes('<span class="tok tok-keyword">int</span>'));
-  console.log('Async long code block tokenization test passed.');
+  assert(block.innerHTML.includes('<span class="tok tok-literal">true</span>'));
+  assert(block.innerHTML.includes('<span class="tok tok-literal">false</span>'));
+  assert(block.innerHTML.includes('<span class="tok tok-literal">null</span>'));
+  assert(
+    block.innerHTML.includes(
+      '<span class="tok tok-string">&quot;&quot;&quot;hi&quot;&quot;&quot;</span>'
+    )
+  );
+  assert(block.innerHTML.includes('<span class="tok tok-keyword">new</span>'));
+  assert(block.innerHTML.includes('<span class="tok tok-class">foo</span>'));
+  assert(block.innerHTML.includes('<span class="tok tok-keyword">extends</span>'));
+  assert(block.innerHTML.includes('<span class="tok tok-class">baz</span>'));
+  console.log('Async long code block tokenization test for new features passed.');
 }, 100);
-

--- a/codeBlockSyntax_java.test.js
+++ b/codeBlockSyntax_java.test.js
@@ -94,3 +94,15 @@ console.log('Class name expectation test passed.');
 output = tokenizeJava('List items;');
 assert(output.includes('<span class="tok tok-class">List</span>'));
 console.log('Uppercase heuristic test passed.');
+
+// Lowercase class names after keywords
+output = tokenizeJava('class a extends b implements c { void m() throws d { new e(); } }');
+assert(output.includes('<span class="tok tok-keyword">extends</span>'));
+assert(output.includes('<span class="tok tok-keyword">implements</span>'));
+assert(output.includes('<span class="tok tok-keyword">throws</span>'));
+assert(output.includes('<span class="tok tok-keyword">new</span>'));
+assert(output.includes('<span class="tok tok-class">b</span>'));
+assert(output.includes('<span class="tok tok-class">c</span>'));
+assert(output.includes('<span class="tok tok-class">d</span>'));
+assert(output.includes('<span class="tok tok-class">e</span>'));
+console.log('Lowercase contextual class name tokenization test passed.');


### PR DESCRIPTION
## Summary
- verify java tokenizer flags lowercase class names after `extends`/`implements`/`throws`/`new`
- expand async tokenization test to cover text blocks, boolean/null literals, and context keywords

## Testing
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac0432c1208325bd230124183b9053