### PR TITLE
Fix emphasis to respect word boundaries

### DIFF
--- a/markdown_editor.js
+++ b/markdown_editor.js
@@ -261,9 +261,18 @@ function parseMarkdown(markdown) {
     }
 
     let processed = sanitize(line).trimEnd();
-    processed = processed.replace(/(\*\*\*|___)(.+?)\1/g, '<strong><em>$2</em></strong>');
-    processed = processed.replace(/(\*\*|__)(.+?)\1/g, '<strong>$2</strong>');
-    processed = processed.replace(/(\*|_)(.+?)\1/g, '<em>$2</em>');
+    processed = processed.replace(
+      /(^|\W)(\*\*\*|___)(?=\S)(.+?)(?<=\S)\2(?=\W|$)/g,
+      '$1<strong><em>$3</em></strong>'
+    );
+    processed = processed.replace(
+      /(^|\W)(\*\*|__)(?=\S)(.+?)(?<=\S)\2(?=\W|$)/g,
+      '$1<strong>$3</strong>'
+    );
+    processed = processed.replace(
+      /(^|\W)(\*|_)(?=\S)(.+?)(?<=\S)\2(?=\W|$)/g,
+      '$1<em>$3</em>'
+    );
     processed = processed.replace(/`([^`]+)`/g, '<code>$1</code>');
     processed = processed.replace(/!\[(.+?)\]\((.+?)\)/g, (m, alt, url) => `<img src="${url}" alt="${alt}" />`);
     processed = processed.replace(/\[(.+?)\]\((.+?)\)/g, (m, text, url) => `<a href="${url}">${text}</a>`);

--- a/parseMarkdown.test.js
+++ b/parseMarkdown.test.js
@@ -155,6 +155,11 @@ const emUnderscoreExpected = '<p><em>italic</em></p>';
 assert.strictEqual(parseMarkdown(emUnderscoreMd), emUnderscoreExpected);
 console.log('Underscore emphasis test passed.');
 
+const underscoreWordMd = 'hello_world';
+const underscoreWordExpected = '<p>hello_world</p>';
+assert.strictEqual(parseMarkdown(underscoreWordMd), underscoreWordExpected);
+console.log('Word with underscore should remain literal test passed.');
+
 const strongStarMd = '**bold**';
 const strongStarExpected = '<p><strong>bold</strong></p>';
 assert.strictEqual(parseMarkdown(strongStarMd), strongStarExpected);


### PR DESCRIPTION
## Summary
- Ensure emphasis markers only match at word boundaries
- Add test confirming words like `hello_world` remain literal

## Testing
- `node parseMarkdown.test.js`
- `node markdownEditor.default.test.js`
- `node markdownEditor.destroy.test.js`
- `node asyncTokenization.test.js`
- `node codeBlockSyntax_java.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac0bf0b398832587971906f77841df