### PR TITLE
refactor: extract sanitize utility

### DIFF
--- a/codeBlockSyntax_java.js
+++ b/codeBlockSyntax_java.js
@@ -1,11 +1,4 @@
-function sanitize(str) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
+import { sanitize } from './utils/sanitize.js';
 
 const languages = {};
 

--- a/markdown_editor.js
+++ b/markdown_editor.js
@@ -1,11 +1,4 @@
-function sanitize(str) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
+import { sanitize } from './utils/sanitize.js';
 
 function parseTables(lines, index) {
   const line = lines[index];

--- a/utils/sanitize.js
+++ b/utils/sanitize.js
@@ -1,0 +1,8 @@
+export function sanitize(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}


### PR DESCRIPTION
## Summary
- move sanitize to shared utils/sanitize.js
- import and re-export sanitize in markdown_editor.js
- reuse sanitize in codeBlockSyntax_java.js

## Testing
- `node parseMarkdown.test.js`
- `node markdownEditor.default.test.js`
- `node markdownEditor.destroy.test.js`
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac0d250bd08325a448e03daa4d7cdb