### PR TITLE
Handle missing clipboard API

### DIFF
--- a/clipboardFallback.test.js
+++ b/clipboardFallback.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import { parseMarkdown, processCodeBlocks } from './markdown_editor.js';
+
+const dom = new JSDOM('');
+const { window } = dom;
+const { document } = window;
+
+global.window = window;
+global.document = document;
+global.navigator = window.navigator;
+
+delete navigator.clipboard;
+
+document.body.innerHTML = parseMarkdown('```\ncode\n```');
+processCodeBlocks(document.body);
+
+const btn = document.querySelector('.copy-btn');
+assert.ok(btn);
+
+assert.doesNotThrow(() => {
+  btn.dispatchEvent(new window.Event('click', { bubbles: true }));
+});
+
+console.log('Clipboard API absence test passed.');

--- a/markdown_editor.js
+++ b/markdown_editor.js
@@ -312,7 +312,13 @@ function processCodeBlocks(container) {
       const btn = pre.querySelector('.copy-btn');
       if (btn) {
         btn.addEventListener('click', () => {
-          navigator.clipboard.writeText(block.textContent);
+          if (navigator.clipboard) {
+            navigator.clipboard
+              .writeText(block.textContent)
+              .catch((err) => {
+                console.error('Failed to copy text to clipboard:', err);
+              });
+          }
         });
       }
     }


### PR DESCRIPTION
## Summary
- guard copy-to-clipboard with `navigator.clipboard` availability and log failures
- add test ensuring missing clipboard API doesn't throw

## Testing
- `node parseMarkdown.test.js`
- `node markdownEditor.default.test.js`
- `node markdownEditor.destroy.test.js`
- `node codeBlockSyntax_java.test.js`
- `node asyncTokenization.test.js`
- `node clipboardFallback.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac0f8d52d083258d0c270262ec2593