### PR TITLE
Await tokenization in async test

### DIFF
--- a/asyncTokenization.test.js
+++ b/asyncTokenization.test.js
@@ -1,40 +1,64 @@
 import assert from 'node:assert';
-const piece = 'boolean a = true; Boolean b = false; Object c = null; String s = """hi"""; new foo(); class bar extends baz {} ';
+
+const piece =
+  'boolean a = true; Boolean b = false; Object c = null; String s = """hi"""; new foo(); class bar extends baz {} ';
 let longCode = '';
 for (let i = 0; i < 400; i++) longCode += piece; // ~40k characters
 
 const block = {
   textContent: longCode,
   className: 'language-java',
-  innerHTML: '',
-  attributes: {'data-tokenized': '0'},
-  setAttribute(name, value) { this.attributes[name] = value; },
-  getAttribute(name) { return this.attributes[name]; }
+  attributes: { 'data-tokenized': '0' },
+  setAttribute(name, value) {
+    this.attributes[name] = value;
+  },
+  getAttribute(name) {
+    return this.attributes[name];
+  },
 };
 
+let innerHTML = '';
+const tokenizationDone = new Promise((resolve) => {
+  let setCount = 0;
+  Object.defineProperty(block, 'innerHTML', {
+    get() {
+      return innerHTML;
+    },
+    set(value) {
+      innerHTML = value;
+      setCount++;
+      if (setCount === 2) resolve();
+    },
+    configurable: true,
+  });
+});
+
 global.document = {
-  querySelectorAll() { return [block]; },
+  querySelectorAll() {
+    return [block];
+  },
   body: {},
 };
 
-global.MutationObserver = function() {
+global.MutationObserver = function () {
   return { observe() {} };
 };
 
 await import('./codeBlockSyntax_java.js');
+await tokenizationDone;
 
-setTimeout(() => {
-  assert(block.innerHTML.includes('<span class="tok tok-literal">true</span>'));
-  assert(block.innerHTML.includes('<span class="tok tok-literal">false</span>'));
-  assert(block.innerHTML.includes('<span class="tok tok-literal">null</span>'));
-  assert(
-    block.innerHTML.includes(
-      '<span class="tok tok-string">&quot;&quot;&quot;hi&quot;&quot;&quot;</span>'
-    )
-  );
-  assert(block.innerHTML.includes('<span class="tok tok-keyword">new</span>'));
-  assert(block.innerHTML.includes('<span class="tok tok-class">foo</span>'));
-  assert(block.innerHTML.includes('<span class="tok tok-keyword">extends</span>'));
-  assert(block.innerHTML.includes('<span class="tok tok-class">baz</span>'));
-  console.log('Async long code block tokenization test for new features passed.');
-}, 100);
+assert(block.innerHTML.includes('<span class="tok tok-literal">true</span>'));
+assert(block.innerHTML.includes('<span class="tok tok-literal">false</span>'));
+assert(block.innerHTML.includes('<span class="tok tok-literal">null</span>'));
+assert(
+  block.innerHTML.includes(
+    '<span class="tok tok-string">&quot;&quot;&quot;hi&quot;&quot;&quot;</span>'
+  )
+);
+assert(block.innerHTML.includes('<span class="tok tok-keyword">new</span>'));
+assert(block.innerHTML.includes('<span class="tok tok-class">foo</span>'));
+assert(block.innerHTML.includes('<span class="tok tok-keyword">extends</span>'));
+assert(block.innerHTML.includes('<span class="tok tok-class">baz</span>'));
+console.log(
+  'Async long code block tokenization test for new features passed.'
+);


### PR DESCRIPTION
## Summary
- Replace `setTimeout` with a Promise that resolves when the code block's `innerHTML` is updated twice.
- Wait for tokenization completion using `await`, then assert on tokenized output.

## Testing
- `for f in *.test.js; do echo $f; node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68ac127be01c83259a52e89faebb4a8a