### PR TITLE
Add Tab key insertion test for MarkdownEditor

### DIFF
--- a/markdownEditor.tab.test.js
+++ b/markdownEditor.tab.test.js
@@ -1,0 +1,28 @@
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import { MarkdownEditor } from './markdown_editor.js';
+
+const dom = new JSDOM(`<textarea class="editor"></textarea><div class="preview"></div>`);
+const { window } = dom;
+const { document } = window;
+
+global.window = window;
+global.document = document;
+
+const textarea = document.querySelector('.editor');
+const preview = document.querySelector('.preview');
+
+const editor = new MarkdownEditor({ textarea, preview });
+
+textarea.value = 'test';
+textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
+
+textarea.dispatchEvent(
+  new window.KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true })
+);
+
+assert.strictEqual(textarea.value, 'test    ');
+
+editor.destroy();
+
+console.log('MarkdownEditor Tab insertion test passed.');


### PR DESCRIPTION
## Summary
- test tab keydown inserts four spaces in the editor

## Testing
- `node asyncTokenization.test.js && node clipboardFallback.test.js && node codeBlockSyntax_java.test.js && node markdownEditor.default.test.js && node markdownEditor.destroy.test.js && node markdownEditor.tab.test.js && node parseMarkdown.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac13795a048325b321a24d267d8149