### PR TITLE
Use explicit navigator definition in clipboard fallback test

### DIFF
--- a/clipboardFallback.test.js
+++ b/clipboardFallback.test.js
@@ -8,9 +8,13 @@ const { document } = window;
 
 global.window = window;
 global.document = document;
-global.navigator = window.navigator;
+Object.defineProperty(globalThis, "navigator", {
+  value: window.navigator,
+  configurable: true,
+  writable: true
+});
 
-delete navigator.clipboard;
+delete globalThis.navigator.clipboard;
 
 document.body.innerHTML = parseMarkdown('```\ncode\n```');
 processCodeBlocks(document.body);


### PR DESCRIPTION
## Summary
- define a `navigator` property on `globalThis` using `Object.defineProperty`
- remove `navigator.clipboard` via `globalThis` to simulate missing Clipboard API

## Testing
- `node clipboardFallback.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac1b7473dc8325b545d45b3c64329c