### PR TITLE
chore: ignore node_modules directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
## Summary
- remove existing `node_modules` folder and keep it out of version control
- add `.gitignore` entry for `node_modules/`

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68ad041abdd08325b43756c0d98cd034