### PR TITLE
feat: add automatic markdown initializer

### DIFF
--- a/md-autoinit.js
+++ b/md-autoinit.js
@@ -1,0 +1,90 @@
+// md-autoinit.js
+// Auto-initialization module for Markdown static previews and live editors.
+// Order of operations on page load:
+//   1. Convert all `.md-temp-preview` elements from Markdown to HTML once.
+//   2. Setup `.md-editor-set` blocks so that textarea inputs update `.md-preview`
+//      elements in real time (with 120ms debounce).
+// This ensures static previews are rendered before editor widgets start syncing.
+
+import { parseMarkdown } from './markdown_editor.js';
+
+// Track initialized textareas to avoid duplicate event binding.
+const initializedEditors = new WeakMap();
+
+/**
+ * Convert all elements with class `md-temp-preview` from Markdown to HTML.
+ * Each element is processed only once using the data attribute `data-md-temp-done`.
+ */
+function initTempPreviews(root = document) {
+  const tempEls = root.querySelectorAll('.md-temp-preview');
+  tempEls.forEach((el) => {
+    if (el.dataset.mdTempDone) return; // Skip already processed elements.
+    const md = el.textContent || '';
+    el.innerHTML = parseMarkdown(md);
+    el.dataset.mdTempDone = '1';
+  });
+}
+
+/**
+ * Initialize live Markdown editors within the given root element.
+ * Each textarea.md-editor updates associated .md-preview elements.
+ */
+function initEditorSet(root) {
+  const textareas = root.querySelectorAll('textarea.md-editor');
+  textareas.forEach((ta) => {
+    if (initializedEditors.has(ta)) return; // Prevent double initialization
+    initializedEditors.set(ta, true);
+
+    // Determine preview elements linked to this textarea.
+    const previews = Array.from(root.querySelectorAll('.md-preview')).filter((pv) => {
+      const target = pv.dataset.mdFor;
+      return !target || (ta.id && target === ta.id);
+    });
+
+    const render = () => {
+      const html = parseMarkdown(ta.value);
+      previews.forEach((pv) => {
+        pv.innerHTML = html;
+      });
+    };
+
+    // Debounce input events (120ms)
+    let timer;
+    const onInput = () => {
+      clearTimeout(timer);
+      timer = setTimeout(render, 120);
+    };
+
+    ta.addEventListener('input', onInput);
+    render(); // Initial render
+  });
+}
+
+/**
+ * Initialize all markdown related elements in the document.
+ * The processing order is important:
+ *   - First handle static `.md-temp-preview` conversions.
+ *   - Then wire up dynamic `.md-editor-set` editors.
+ */
+function autoInit(root = document) {
+  // Step 1: static conversion
+  initTempPreviews(root);
+
+  // Step 2: dynamic editor wiring
+  const sets = root.querySelectorAll('#md-editor-set, .md-editor-set');
+  sets.forEach((set) => initEditorSet(set));
+}
+
+// Auto-run on DOMContentLoaded or immediately if already loaded
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => autoInit(), { once: true });
+} else {
+  autoInit();
+}
+
+// Optional global exposure for manual invocation
+if (typeof window !== 'undefined') {
+  window.MdAutoInit = autoInit;
+}
+
+export { autoInit };

--- a/thread.html
+++ b/thread.html
@@ -11,7 +11,7 @@
       href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="thread.css"/>
+    <link rel="stylesheet" href="thread.css" />
   </head>
   <body>
     <div class="container mt-5">
@@ -38,11 +38,18 @@
       <div id="answers-pane" class="pane active">
         <ul class="list-group">
           <li class="list-group-item">
-            <strong>Bob:</strong> Promiseはコールバックの連鎖を避けるために使うオブジェクトです。
-            async/awaitはPromiseを同期処理のように書ける糖衣構文です。
+            <strong>Bob:</strong>
+            <div class="md-temp-preview">
+              <p># 見出し1 ## 見出し2 ### 見出し3</p>
+              Promiseはコールバックの連鎖を避けるために使うオブジェクトです。
+              async/awaitはPromiseを同期処理のように書ける糖衣構文です。
+            </div>
           </li>
           <li class="list-group-item">
-            <strong>Charlie:</strong> 例を挙げると理解しやすいですよ。
+            <div class="md-temp-preview">
+              <p># 見出し1 ## 見出し2 ### 見出し3</p>
+              <strong>Charlie:</strong> 例を挙げると理解しやすいですよ。
+            </div>
           </li>
         </ul>
         <div class="mt-3">
@@ -50,8 +57,20 @@
           <form>
             <div class="md-editor-set">
               <div class="tabs">
-                <button class="active btn btn-outline-secondary" data-target="answer-editor-pane">編集</button>
-                <button class="btn btn-outline-secondary" data-target="answer-preview-pane">プレビュー</button>
+                <button
+                  type="button"
+                  class="active btn btn-outline-secondary"
+                  data-target="answer-editor-pane"
+                >
+                  編集
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary"
+                  data-target="answer-preview-pane"
+                >
+                  プレビュー
+                </button>
               </div>
               <div id="answer-editor-pane" class="pane active">
                 <textarea
@@ -76,10 +95,18 @@
       <div id="comments-pane" class="pane">
         <ul class="list-group">
           <li class="list-group-item">
-            <strong>Dave:</strong> 私も気になっていました！
+            <strong>Dave:</strong>
+            <div class="md-temp-preview">
+              # 見出し1 ## 見出し2 ### 見出し3 #### 見出し4 ##### 見出し5 ######
+              見出し6 私も気になっていました！
+            </div>
           </li>
           <li class="list-group-item">
-            <strong>Eve:</strong> async/awaitはエラーハンドリングがtry-catchでできるのが便利です。
+            <strong>Eve:</strong>
+            <div class="md-temp-preview">
+              # 見出し1 ## 見出し2 ### 見出し3
+              async/awaitはエラーハンドリングがtry-catchでできるのが便利です。
+            </div>
           </li>
         </ul>
         <div class="mt-3">
@@ -94,7 +121,7 @@
           </form>
         </div>
       </div>
-  </div>
+    </div>
     <script type="module" src="./md-autoinit.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add `md-autoinit.js` module to auto-convert `.md-temp-preview` content and wire up live `.md-editor-set`
- initialize on DOMContentLoaded with ordered static and dynamic setup

## Testing
- `for f in *.test.js; do echo "Running $f"; node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68af8e58460083258f12640bb997474d