### PR TITLE
Enhance thread answer form with markdown editor

### DIFF
--- a/thread.html
+++ b/thread.html
@@ -47,14 +47,17 @@
         </ul>
         <div class="mt-3">
           <h5>回答を投稿</h5>
-          <form>
-            <textarea
-              class="form-control"
-              rows="4"
-              placeholder="回答を入力してください"
-            ></textarea>
-            <button class="btn btn-primary mt-2" type="button">投稿</button>
-          </form>
+          <div class="md-editor-set">
+            <form>
+              <textarea
+                class="form-control md-editor"
+                rows="4"
+                placeholder="回答を入力してください"
+              ></textarea>
+              <div class="md-preview"></div>
+              <button class="btn btn-primary mt-2" type="button">投稿</button>
+            </form>
+          </div>
         </div>
       </div>
 
@@ -80,6 +83,7 @@
           </form>
         </div>
       </div>
-    </div>
+  </div>
+    <script type="module" src="./md-autoinit.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap answer form with markdown editor container
- add live preview support and auto-init script on thread page

## Testing
- `for f in *.test.js; do echo "Running $f"; node "$f"; echo; done`

------
https://chatgpt.com/codex/tasks/task_e_68afa0415a448325aafe702c0928b6c1